### PR TITLE
Add Notion sync integration scaffolding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-# Add your Python dependencies here
+notion-client>=2.0.0
+structlog>=24.1.0
+tenacity>=8.2.3

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts package for PR-CYBR data integration workflows."""

--- a/scripts/notion_sync.py
+++ b/scripts/notion_sync.py
@@ -1,0 +1,78 @@
+"""Command line entrypoint for synchronising GitHub events with Notion."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Treat this module as a package so that ``python -m scripts.notion_sync`` can
+# co-exist with the supporting modules living under ``scripts/notion_sync``.
+_PACKAGE_DIR = Path(__file__).with_name("notion_sync")
+if _PACKAGE_DIR.exists():
+    __path__ = [str(_PACKAGE_DIR)]  # type: ignore[name-defined]
+    if __spec__ is not None:  # pragma: no cover - attribute absent in some tooling
+        __spec__.submodule_search_locations = __path__  # type: ignore[attr-defined]
+
+from scripts.notion_sync.client import NotionSyncClient
+from scripts.notion_sync.mappers import map_event_to_page
+from scripts.notion_sync.utils import (
+    configure_logger,
+    ensure_api_token,
+    ensure_database_id,
+    load_github_event_payload,
+    resolve_event_name,
+)
+
+
+def _parse_arguments(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Synchronise GitHub events into Notion")
+    parser.add_argument("--event-name", help="GitHub event name", default=None)
+    parser.add_argument("--event-path", help="Path to the GitHub event payload", default=None)
+    parser.add_argument("--database-id", help="Target Notion database identifier", default=None)
+    parser.add_argument("--api-token", help="Notion integration token", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_arguments(argv or sys.argv[1:])
+    logger = configure_logger()
+
+    try:
+        event_name = resolve_event_name(args.event_name)
+        event_payload = load_github_event_payload(args.event_path)
+        database_id = ensure_database_id(args.database_id)
+        api_token = ensure_api_token(args.api_token)
+    except Exception as error:  # pragma: no cover - CLI error handling
+        logger.error("notion_sync_configuration_error", error=str(error))
+        return 1
+
+    try:
+        operation = map_event_to_page(event_name, event_payload, database_id)
+    except Exception as error:
+        logger.error("notion_sync_mapping_error", event_name=event_name, error=str(error))
+        return 1
+
+    client = NotionSyncClient(token=api_token, logger=logger)
+
+    try:
+        response = client.upsert(operation)
+    except Exception as error:
+        logger.error(
+            "notion_sync_upsert_failed",
+            error=str(error),
+            github_id=operation.github_id,
+        )
+        return 1
+
+    notion_page_id = response.get("id") if isinstance(response, dict) else None
+    logger.info(
+        "notion_sync_complete",
+        event_name=event_name,
+        github_id=operation.github_id,
+        notion_page_id=notion_page_id,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/scripts/notion_sync/__init__.py
+++ b/scripts/notion_sync/__init__.py
@@ -1,0 +1,9 @@
+"""Notion synchronisation helpers for GitHub automation."""
+from .client import NotionSyncClient
+from .mappers import PageOperation, map_event_to_page
+
+__all__ = [
+    "NotionSyncClient",
+    "PageOperation",
+    "map_event_to_page",
+]

--- a/scripts/notion_sync/client.py
+++ b/scripts/notion_sync/client.py
@@ -1,0 +1,94 @@
+"""Notion client abstractions with retry support."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from notion_client import Client
+from notion_client.errors import APIResponseError
+import structlog
+from tenacity import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .mappers import PageOperation
+
+
+class NotionSyncClient:
+    """A thin wrapper around the official Notion SDK with retries."""
+
+    def __init__(self, token: str, logger: structlog.BoundLogger):
+        self._client = Client(auth=token)
+        self._logger = logger.bind(component="notion_client")
+
+    def _call_with_retry(self, func, *args, **kwargs):
+        retrying = Retrying(
+            stop=stop_after_attempt(5),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception_type(APIResponseError),
+            reraise=True,
+        )
+        try:
+            for attempt in retrying:
+                with attempt:
+                    return func(*args, **kwargs)
+        except RetryError as exc:  # pragma: no cover - defensive logging path
+            self._logger.error("notion_api_retry_failed", error=str(exc.last_attempt.exception()))
+            raise
+
+    def _find_page_by_github_id(self, operation: PageOperation) -> str | None:
+        if not operation.github_id:
+            return None
+        try:
+            response = self._call_with_retry(
+                self._client.databases.query,
+                **{
+                    "database_id": operation.database_id,
+                    "filter": {
+                        "property": "GitHub ID",
+                        "rich_text": {"equals": operation.github_id},
+                    },
+                    "page_size": 1,
+                },
+            )
+        except APIResponseError as error:
+            self._logger.warning(
+                "notion_database_query_failed",
+                github_id=operation.github_id,
+                error_code=getattr(error, "code", "unknown"),
+                message=str(error),
+            )
+            raise
+        results = response.get("results", [])
+        if results:
+            page_id = results[0]["id"]
+            self._logger.debug("existing_page_found", github_id=operation.github_id, page_id=page_id)
+            return page_id
+        return None
+
+    def _create_page(self, operation: PageOperation) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "parent": {"database_id": operation.database_id},
+            "properties": operation.properties,
+        }
+        if operation.children:
+            payload["children"] = operation.children
+        self._logger.info("creating_notion_page", github_id=operation.github_id)
+        return self._call_with_retry(self._client.pages.create, **payload)
+
+    def _update_page(self, page_id: str, operation: PageOperation) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "page_id": page_id,
+            "properties": operation.properties,
+        }
+        if operation.children is not None:
+            payload["children"] = operation.children
+        self._logger.info("updating_notion_page", github_id=operation.github_id, page_id=page_id)
+        return self._call_with_retry(self._client.pages.update, **payload)
+
+    def upsert(self, operation: PageOperation) -> Dict[str, Any]:
+        """Create or update a Notion page based on the supplied operation."""
+        page_id = operation.page_id or self._find_page_by_github_id(operation)
+        if page_id:
+            return self._update_page(page_id, operation)
+        return self._create_page(operation)
+
+
+__all__ = ["NotionSyncClient"]

--- a/scripts/notion_sync/mappers.py
+++ b/scripts/notion_sync/mappers.py
@@ -1,0 +1,222 @@
+"""Translation utilities converting GitHub events into Notion page payloads."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class PageOperation:
+    """Representation of a Notion page upsert operation."""
+
+    database_id: str
+    properties: Dict[str, Any]
+    github_id: Optional[str]
+    page_id: Optional[str] = None
+    children: Optional[List[Dict[str, Any]]] = None
+
+
+def _title_property(value: str) -> Dict[str, Any]:
+    return {"title": [{"type": "text", "text": {"content": value[:2000]}}]}
+
+
+def _rich_text_property(value: str) -> Dict[str, Any]:
+    return {"rich_text": [{"type": "text", "text": {"content": value[:2000]}}]}
+
+
+def _url_property(value: Optional[str]) -> Dict[str, Any]:
+    return {"url": value or None}
+
+
+def _date_property(dt: datetime) -> Dict[str, Any]:
+    return {"date": {"start": dt.isoformat()}}
+
+
+def _multi_line_children(body: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+    if not body:
+        return None
+    paragraphs = []
+    for line in body.splitlines():
+        if not line.strip():
+            paragraphs.append({"object": "block", "type": "paragraph", "paragraph": {"rich_text": []}})
+            continue
+        paragraphs.append(
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {"content": line[:2000]},
+                        }
+                    ]
+                },
+            }
+        )
+    return paragraphs or None
+
+
+def _base_properties(database_id: str, github_id: str, name: str, resource_type: str, url: Optional[str], state: Optional[str]) -> PageOperation:
+    now = datetime.now(timezone.utc)
+    properties = {
+        "Name": _title_property(name),
+        "GitHub ID": _rich_text_property(github_id),
+        "Type": _rich_text_property(resource_type),
+        "Last Synced": _date_property(now),
+    }
+    if state:
+        properties["State"] = _rich_text_property(state)
+    if url:
+        properties["GitHub URL"] = _url_property(url)
+    return PageOperation(database_id=database_id, properties=properties, github_id=github_id)
+
+
+def map_issue_event(payload: Dict[str, Any], database_id: str) -> PageOperation:
+    issue = payload["issue"]
+    github_id = issue.get("node_id") or str(issue.get("id"))
+    name = f"Issue #{issue['number']}: {issue['title']}"
+    operation = _base_properties(
+        database_id=database_id,
+        github_id=github_id,
+        name=name,
+        resource_type="Issue",
+        url=issue.get("html_url"),
+        state=issue.get("state"),
+    )
+    body_children = _multi_line_children(issue.get("body"))
+    if body_children:
+        operation.children = body_children
+    if payload.get("notion_page_id"):
+        operation.page_id = payload["notion_page_id"]
+    elif issue.get("notion_page_id"):
+        operation.page_id = issue["notion_page_id"]
+    if issue.get("user", {}).get("login"):
+        operation.properties["Author"] = _rich_text_property(issue["user"]["login"])
+    return operation
+
+
+def map_pull_request_event(payload: Dict[str, Any], database_id: str) -> PageOperation:
+    pull_request = payload["pull_request"]
+    github_id = pull_request.get("node_id") or str(pull_request.get("id"))
+    name = f"PR #{pull_request['number']}: {pull_request['title']}"
+    operation = _base_properties(
+        database_id=database_id,
+        github_id=github_id,
+        name=name,
+        resource_type="Pull Request",
+        url=pull_request.get("html_url"),
+        state=pull_request.get("state"),
+    )
+    body_children = _multi_line_children(pull_request.get("body"))
+    if body_children:
+        operation.children = body_children
+    if payload.get("notion_page_id"):
+        operation.page_id = payload["notion_page_id"]
+    elif pull_request.get("notion_page_id"):
+        operation.page_id = pull_request["notion_page_id"]
+    if pull_request.get("user", {}).get("login"):
+        operation.properties["Author"] = _rich_text_property(pull_request["user"]["login"])
+    if pull_request.get("base", {}).get("ref"):
+        operation.properties["Base Branch"] = _rich_text_property(pull_request["base"]["ref"])
+    if pull_request.get("head", {}).get("ref"):
+        operation.properties["Head Branch"] = _rich_text_property(pull_request["head"]["ref"])
+    return operation
+
+
+def map_discussion_event(payload: Dict[str, Any], database_id: str) -> PageOperation:
+    discussion = payload["discussion"]
+    github_id = discussion.get("node_id") or str(discussion.get("id"))
+    name = f"Discussion: {discussion['title']}"
+    operation = _base_properties(
+        database_id=database_id,
+        github_id=github_id,
+        name=name,
+        resource_type="Discussion",
+        url=discussion.get("html_url"),
+        state=discussion.get("state"),
+    )
+    body_children = _multi_line_children(discussion.get("body"))
+    if body_children:
+        operation.children = body_children
+    if payload.get("notion_page_id"):
+        operation.page_id = payload["notion_page_id"]
+    elif discussion.get("notion_page_id"):
+        operation.page_id = discussion["notion_page_id"]
+    if discussion.get("category", {}).get("name"):
+        operation.properties["Category"] = _rich_text_property(discussion["category"]["name"])
+    return operation
+
+
+def map_project_item_event(payload: Dict[str, Any], database_id: str) -> PageOperation:
+    project_item = payload.get("project_item") or payload.get("projects_v2_item") or {}
+    github_id = project_item.get("node_id") or str(project_item.get("id", payload.get("id", "unknown")))
+    title = project_item.get("title") or project_item.get("content", {}).get("title") or "Project Item"
+    operation = _base_properties(
+        database_id=database_id,
+        github_id=github_id,
+        name=title,
+        resource_type="Project Item",
+        url=project_item.get("url") or project_item.get("html_url"),
+        state=project_item.get("status") or project_item.get("state"),
+    )
+    if payload.get("notion_page_id"):
+        operation.page_id = payload["notion_page_id"]
+    if project_item.get("assignee"):
+        assignee = project_item["assignee"].get("login") or project_item["assignee"].get("name")
+        if assignee:
+            operation.properties["Assignee"] = _rich_text_property(assignee)
+    summary = project_item.get("content", {}).get("body") or project_item.get("summary")
+    body_children = _multi_line_children(summary)
+    if body_children:
+        operation.children = body_children
+    return operation
+
+
+def map_workflow_run_event(payload: Dict[str, Any], database_id: str) -> PageOperation:
+    workflow_run = payload["workflow_run"]
+    github_id = workflow_run.get("node_id") or str(workflow_run.get("id"))
+    name = f"Workflow: {workflow_run['name']}"
+    operation = _base_properties(
+        database_id=database_id,
+        github_id=github_id,
+        name=name,
+        resource_type="Workflow Run",
+        url=workflow_run.get("html_url"),
+        state=workflow_run.get("conclusion") or workflow_run.get("status"),
+    )
+    if payload.get("notion_page_id"):
+        operation.page_id = payload["notion_page_id"]
+    summary = workflow_run.get("display_title") or workflow_run.get("head_branch")
+    if summary:
+        operation.properties["Summary"] = _rich_text_property(summary)
+    return operation
+
+
+_EVENT_MAPPERS: Dict[str, Callable[[Dict[str, Any], str], PageOperation]] = {
+    "issues": map_issue_event,
+    "pull_request": map_pull_request_event,
+    "pull_request_target": map_pull_request_event,
+    "pull_request_review": map_pull_request_event,
+    "discussion": map_discussion_event,
+    "discussion_comment": map_discussion_event,
+    "projects_v2_item": map_project_item_event,
+    "project": map_project_item_event,
+    "workflow_run": map_workflow_run_event,
+}
+
+
+def map_event_to_page(event_name: str, payload: Dict[str, Any], database_id: str) -> PageOperation:
+    """Return the :class:`PageOperation` for the given GitHub event."""
+    try:
+        mapper = _EVENT_MAPPERS[event_name]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unsupported GitHub event: {event_name}") from exc
+    return mapper(payload, database_id)
+
+
+__all__ = [
+    "PageOperation",
+    "map_event_to_page",
+]

--- a/scripts/notion_sync/utils.py
+++ b/scripts/notion_sync/utils.py
@@ -1,0 +1,99 @@
+"""Utility helpers for the Notion synchronisation workflow."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+import logging
+
+import structlog
+
+
+def configure_logger() -> structlog.BoundLogger:
+    """Configure and return a structlog logger instance.
+
+    The configuration is idempotent and safe to call multiple times. It
+    produces JSON logs that are easy to ingest by log aggregation platforms.
+    """
+    if not structlog.is_configured():
+        log_level_name = os.environ.get("NOTION_SYNC_LOG_LEVEL", "INFO").upper()
+        log_level = getattr(logging, log_level_name, logging.INFO)
+        logging.basicConfig(level=log_level)
+        structlog.configure(
+            processors=[
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.processors.add_log_level,
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.JSONRenderer(),
+            ],
+            wrapper_class=structlog.make_filtering_bound_logger(log_level),
+            cache_logger_on_first_use=True,
+        )
+    return structlog.get_logger("notion_sync")
+
+
+def load_github_event_payload(event_path: Optional[str]) -> Dict[str, Any]:
+    """Load and parse the GitHub event payload file.
+
+    Args:
+        event_path: Optional path to the GitHub event payload JSON file. When
+            ``None`` the ``GITHUB_EVENT_PATH`` environment variable is used.
+
+    Returns:
+        Parsed JSON payload as a dictionary.
+
+    Raises:
+        FileNotFoundError: If the event payload file cannot be located.
+        json.JSONDecodeError: If the event payload cannot be parsed.
+    """
+    if not event_path:
+        event_path = os.environ.get("GITHUB_EVENT_PATH")
+
+    if not event_path:
+        raise FileNotFoundError(
+            "GitHub event payload path was not provided. Set the --event-path "
+            "argument or the GITHUB_EVENT_PATH environment variable."
+        )
+
+    path = Path(event_path)
+    if not path.exists():
+        raise FileNotFoundError(f"GitHub event payload not found at: {path}")
+
+    with path.open("r", encoding="utf-8") as file_obj:
+        return json.load(file_obj)
+
+
+def resolve_event_name(explicit_event_name: Optional[str] = None) -> str:
+    """Resolve the GitHub event name from the CLI or the environment."""
+    event_name = explicit_event_name or os.environ.get("GITHUB_EVENT_NAME")
+    if not event_name:
+        raise RuntimeError(
+            "GitHub event name is required. Provide --event-name or set "
+            "GITHUB_EVENT_NAME in the environment."
+        )
+    return event_name
+
+
+def ensure_database_id(explicit_database_id: Optional[str] = None) -> str:
+    """Resolve the target Notion database identifier."""
+    database_id = explicit_database_id or os.environ.get("NOTION_DATABASE_ID")
+    if not database_id:
+        raise RuntimeError(
+            "A Notion database ID is required. Provide --database-id or set "
+            "NOTION_DATABASE_ID in the environment."
+        )
+    return database_id
+
+
+def ensure_api_token(explicit_token: Optional[str] = None) -> str:
+    """Resolve the Notion API token required for authentication."""
+    token = explicit_token or os.environ.get("NOTION_API_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "A Notion integration token is required. Provide --api-token or "
+            "set NOTION_API_TOKEN in the environment."
+        )
+    return token

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+
+core_packages = find_packages(where='src')
+script_packages = find_packages(where='.', include=['scripts', 'scripts.*'])
+packages = list(dict.fromkeys(core_packages + script_packages))
+
+with open('requirements.txt', encoding='utf-8') as requirements_file:
+    requirements = [line.strip() for line in requirements_file if line.strip() and not line.startswith('#')]
+
 
 setup(
     name='PR_CYBR_DATA_INTEGRATION_AGENT',
     version='0.1.0',
-    packages=find_packages(where='src'),
-    package_dir={'': 'src'},
-    install_requires=[
-        # Add dependencies from requirements.txt
-    ],
+    packages=packages,
+    package_dir={'': 'src', 'scripts': 'scripts'},
+    install_requires=requirements,
     author='PR-CYBR',
     author_email='support@pr-cybr.com',
     description='PR-CYBR-DATA-INTEGRATION-AGENT',


### PR DESCRIPTION
## Summary
- introduce a Notion sync package that maps GitHub events into Notion page operations with retrying client utilities
- add a CLI entrypoint for executing the synchronisation via `python -m scripts.notion_sync`
- update packaging metadata and dependencies to ship the new tooling

## Testing
- python -m compileall scripts/notion_sync.py scripts/notion_sync

------
https://chatgpt.com/codex/tasks/task_e_68fc348da0348323ba1463a9dfcbd7f0