### PR TITLE
Add Notion sync workflow

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,0 +1,80 @@
+name: notion-sync
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - closed
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - closed
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+  discussion:
+    types:
+      - created
+      - edited
+      - answered
+      - unanswered
+      - labeled
+      - unlabeled
+  project:
+    types:
+      - created
+      - edited
+      - deleted
+      - archived
+      - reopened
+  workflow_run:
+    workflows:
+      - CI/CD
+    types:
+      - completed
+
+permissions:
+  issues: read
+  pull-requests: read
+  discussions: read
+  projects: read
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -e .
+
+      - name: Run Notion sync script
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_ISSUES_DB_ID: ${{ secrets.NOTION_ISSUES_DB_ID }}
+          NOTION_PRS_DB_ID: ${{ secrets.NOTION_PRS_DB_ID }}
+          NOTION_PROJECT_DB_ID: ${{ secrets.NOTION_PROJECT_DB_ID }}
+          NOTION_DISCUSSIONS_DB_ID: ${{ secrets.NOTION_DISCUSSIONS_DB_ID }}
+        run: |
+          python -m scripts.notion_sync \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --event-type "$GITHUB_EVENT_NAME"


### PR DESCRIPTION
## Summary
- add a Notion synchronization workflow that reacts to repo activity and CI/CD completions
- provision least-privilege permissions and Python environment setup for the sync script
- run the Notion sync script with required Terraform-managed secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc34919444832386f6cb639a24d0bf