### PR TITLE
Document Notion integration and add Terraform variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The **PR-CYBR-DATA-INTEGRATION-AGENT** facilitates seamless data ingestion, tran
 - **Docker**: Optional, for containerized deployment.
 - **Access to GitHub Actions**: For automated workflows.
 
+### Branching & Secret Management Expectations
+
+- **Follow the spec-bootstrap branching model**: Create feature work from the `spec-main` lineage (for example, `spec-main`, `spec-dev`, or `spec/feature-*`). Avoid pushing directly to `main`; CI/CD automation is only wired for spec-bootstrap-compliant branches.
+- **Rely on Terraform Cloud for secrets**: Workflows draw credentials—such as Notion tokens, database IDs, and other service keys—from Terraform-managed workspace variables. Ensure the Terraform Cloud workspace is populated before running provisioning or sync scripts locally or in CI.
+
 ### Local Setup
 
 To set up the `PR-CYBR-DATA-INTEGRATION-AGENT` locally:

--- a/agent-variables.tf
+++ b/agent-variables.tf
@@ -78,3 +78,15 @@ variable "AGENT_COLLAB" {
   sensitive   = true
   description = "Token for governance, discussions, issues, project boards"
 }
+
+# --- Notion Integration ---
+variable "NOTION_TOKEN" {
+  type        = string
+  sensitive   = true
+  description = "Integration token used for Notion sync operations"
+}
+
+variable "NOTION_DATABASE_IDS" {
+  type        = map(string)
+  description = "Mapping of Notion database names to their corresponding IDs"
+}

--- a/docs/integrations/notion-sync.md
+++ b/docs/integrations/notion-sync.md
@@ -1,0 +1,53 @@
+# Notion Sync Integration
+
+This guide walks through provisioning the Notion integration that powers the PR-CYBR Data Integration Agent, configuring Terraform Cloud workspace variables, and confirming that the integration has the proper capabilities.
+
+## 1. Provision the Notion Integration
+
+1. Navigate to the [Notion integrations dashboard](https://www.notion.so/my-integrations) and select **+ New integration**.
+2. Give the integration a descriptive name such as `PR-CYBR Data Integration Agent`.
+3. Set the workspace that owns the databases you plan to sync.
+4. Under **Capabilities**, enable the following scopes:
+   - **Read content** – required for ingesting pages and database entries.
+   - **Update content** – required for writing sync results back to Notion.
+   - **Insert content** – required if the agent needs to create new database rows.
+   - **Read user information** – optional, but recommended for enriching sync metadata.
+5. Click **Submit** and copy the generated internal integration token. This value is only shown once.
+
+> ℹ️ **Share databases with the integration**: In Notion, open each database that should be synchronized, choose **Share**, and grant access to the newly created integration. Record the database IDs from the page URL (the 32-character UUID segment after the last `/`).
+
+## 2. Configure Terraform Cloud Workspace Variables
+
+Terraform Cloud manages the runtime configuration for this repository. Add the following variables to the workspace connected to the Data Integration Agent:
+
+| Name | Type | Sensitive | Value Guidance |
+| --- | --- | --- | --- |
+| `NOTION_TOKEN` | Terraform (string) | ✅ | Paste the integration token copied from Notion. |
+| `NOTION_DATABASE_IDS` | Terraform (HCL) | ❌ | Provide a map of logical database names to their UUIDs. Example below. |
+
+Example HCL for the `NOTION_DATABASE_IDS` variable:
+
+```hcl
+{
+  pipelines = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  datasets  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  reports   = "cccccccccccccccccccccccccccccccc"
+}
+```
+
+Mark `NOTION_TOKEN` as **Sensitive** so Terraform Cloud redacts it in logs. Database IDs are identifiers rather than credentials and can remain non-sensitive, but keep them managed in Terraform Cloud to avoid hard-coding values in the repository.
+
+## 3. Validate Integration Scopes and Connectivity
+
+1. In the Notion integrations dashboard, open the integration and confirm the scopes listed above remain enabled.
+2. From any environment that has access to the Terraform Cloud variables, run a smoke test to ensure the integration works:
+
+   ```bash
+   export NOTION_TOKEN="$(terraform output -raw notion_token)"
+   python -m scripts.notion_smoke_test
+   ```
+
+   Replace the smoke test command with your repository's verification script if one exists.
+3. Review Terraform Cloud run logs after applying workspace variables to ensure the agent can reach Notion without permission errors.
+
+Once these steps are complete, the Data Integration Agent will have the credentials and database identifiers it needs to synchronize records with Notion.


### PR DESCRIPTION
## Summary
- declare Terraform workspace variables for the Notion integration token and database identifiers
- add an integration guide for configuring Notion and Terraform Cloud workspace variables
- update onboarding documentation to stress spec-bootstrap branching and Terraform-managed secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc3494cb088323bbec81a3a9738543