### PR TITLE
Add staged Notion sync pipeline with robust error handling

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,0 +1,113 @@
+name: Notion Synchronisation Pipeline
+
+on:
+  push:
+    branches:
+      - "staging/**"
+  workflow_dispatch:
+    inputs:
+      promote:
+        description: "Promote the latest validated staging build to production"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      dry-run:
+        description: "Run the synchronisation in dry-run mode"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  staging-validation:
+    if: github.event_name == 'push'
+    name: Validate in staging
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: pytest tests/notion_sync
+
+      - name: Dry-run Notion sync
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Tokens not available; skipping dry-run execution."
+            exit 0
+          fi
+          echo "Ensuring NOTION_TOKEN is scoped to database access only."
+          ORG_ARG=""
+          if [ -n "${{ vars.GITHUB_ORG }}" ]; then
+            ORG_ARG="--github-org ${{ vars.GITHUB_ORG }}"
+          fi
+          python -m agent_logic.notion_sync.cli --database-id ${{ secrets.NOTION_DATABASE_ID }} $ORG_ARG --dry-run
+
+  production-sync:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote == 'true'
+    name: Promote to production
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Execute Notion sync
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Required tokens are missing; unable to run production sync."
+            exit 1
+          fi
+          echo "Running production sync with minimal permissions."
+          if [ "${{ github.event.inputs.dry-run }}" = "true" ]; then
+            EXTRA_ARGS="--dry-run"
+          else
+            EXTRA_ARGS=""
+          fi
+          ORG_ARG=""
+          if [ -n "${{ vars.GITHUB_ORG }}" ]; then
+            ORG_ARG="--github-org ${{ vars.GITHUB_ORG }}"
+          fi
+          python -m agent_logic.notion_sync.cli --database-id ${{ secrets.NOTION_DATABASE_ID }} $ORG_ARG --repo-id-property "Repository ID" $EXTRA_ARGS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-# Add your Python dependencies here
+# Runtime dependencies
+requests>=2.31.0
+
+# Test dependencies
+pytest>=7.4.0

--- a/src/agent_logic/notion_sync/__init__.py
+++ b/src/agent_logic/notion_sync/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for synchronising GitHub repositories with Notion."""
+
+from .client import NotionSyncClient, NotionApiError, GitHubApiError, SyncSummary  # noqa: F401
+from . import mappers  # noqa: F401

--- a/src/agent_logic/notion_sync/cli.py
+++ b/src/agent_logic/notion_sync/cli.py
@@ -1,0 +1,76 @@
+"""Command line entry-point for the Notion synchronisation utility."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+from .client import GitHubClient, NotionApi, NotionSyncClient, SyncSummary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synchronise GitHub repositories with a Notion database")
+    parser.add_argument("--database-id", required=True, help="Target Notion database identifier")
+    parser.add_argument("--github-org", help="GitHub organisation to pull repositories from")
+    parser.add_argument("--repo-id-property", default="Repository ID", help="Notion property that stores repo IDs")
+    parser.add_argument("--dry-run", action="store_true", help="Run without writing changes to Notion")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (default: INFO)")
+    return parser
+
+
+def _build_sync_client(args: argparse.Namespace) -> NotionSyncClient:
+    notion_token = os.environ.get("NOTION_TOKEN")
+    if not notion_token:
+        raise SystemExit("NOTION_TOKEN environment variable must be set")
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        raise SystemExit("GITHUB_TOKEN environment variable must be set")
+
+    notion_api = NotionApi(notion_token)
+    github_client = GitHubClient(github_token, org=args.github_org)
+    return NotionSyncClient(
+        notion_api,
+        github_client,
+        database_id=args.database_id,
+        repo_id_property=args.repo_id_property,
+    )
+
+
+def _run_sync(client: NotionSyncClient, *, dry_run: bool) -> SyncSummary:
+    summary = client.sync_repositories(dry_run=dry_run)
+    return summary
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    logger = logging.getLogger("notion_sync")
+    logger.debug("Starting Notion synchronisation")
+
+    try:
+        client = _build_sync_client(args)
+    except SystemExit as exc:
+        logger.error(str(exc))
+        return int(exc.code or 1)
+
+    summary = _run_sync(client, dry_run=args.dry_run)
+
+    if summary.failed:
+        logger.error(
+            "Synchronisation completed with %s failures out of %s repositories", summary.failed, summary.processed
+        )
+        return 1
+
+    logger.info(
+        "Synchronisation completed successfully for %s repositories", summary.succeeded
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/agent_logic/notion_sync/client.py
+++ b/src/agent_logic/notion_sync/client.py
@@ -1,0 +1,225 @@
+"""Client helpers for synchronising GitHub repositories with Notion."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, MutableMapping, Optional
+
+import requests
+
+from . import mappers
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NotionApiError(RuntimeError):
+    """Raised when the Notion API returns an error."""
+
+
+class GitHubApiError(RuntimeError):
+    """Raised when the GitHub API returns an error."""
+
+
+@dataclass
+class SyncSummary:
+    """Summarises the outcome of a synchronisation run."""
+
+    processed: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    errors: List[Dict[str, str]] = field(default_factory=list)
+
+    def record_success(self) -> None:
+        self.processed += 1
+        self.succeeded += 1
+
+    def record_failure(self, repository: Mapping[str, object], message: str) -> None:
+        self.processed += 1
+        self.failed += 1
+        self.errors.append({
+            "repository": str(repository.get("full_name") or repository.get("name")),
+            "message": message,
+        })
+
+
+class NotionApi:
+    """Small wrapper around the Notion API endpoints used by the sync."""
+
+    def __init__(self, token: str, *, base_url: str = "https://api.notion.com/v1") -> None:
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Notion-Version": "2022-06-28",
+                "Content-Type": "application/json",
+            }
+        )
+        self._base_url = base_url.rstrip("/")
+
+    def query_database(self, database_id: str, filter_body: Mapping[str, object]) -> Mapping[str, object]:
+        response = self._session.post(
+            f"{self._base_url}/databases/{database_id}/query",
+            json={"filter": filter_body},
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise NotionApiError(f"Failed to query Notion database: {response.text}")
+        return response.json()
+
+    def create_page(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        response = self._session.post(
+            f"{self._base_url}/pages",
+            json=payload,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise NotionApiError(f"Failed to create Notion page: {response.text}")
+        return response.json()
+
+    def update_page(self, page_id: str, properties: Mapping[str, object]) -> None:
+        response = self._session.patch(
+            f"{self._base_url}/pages/{page_id}",
+            json={"properties": properties},
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise NotionApiError(f"Failed to update Notion page: {response.text}")
+
+
+class GitHubClient:
+    """Small wrapper around the GitHub REST API to list repositories."""
+
+    def __init__(self, token: str, *, org: Optional[str] = None, base_url: str = "https://api.github.com") -> None:
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            }
+        )
+        self._base_url = base_url.rstrip("/")
+        self._org = org
+
+    def list_repositories(self) -> Iterable[Mapping[str, object]]:
+        url = f"{self._base_url}/user/repos"
+        if self._org:
+            url = f"{self._base_url}/orgs/{self._org}/repos"
+
+        params = {"per_page": 100, "type": "all"}
+        repositories: List[Mapping[str, object]] = []
+
+        while url:
+            response = self._session.get(url, params=params, timeout=30)
+            if response.status_code >= 400:
+                raise GitHubApiError(f"Failed to list repositories: {response.text}")
+            repositories.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+            params = None
+
+        return repositories
+
+
+class NotionSyncClient:
+    """Coordinates synchronisation between GitHub and Notion."""
+
+    def __init__(
+        self,
+        notion_api: NotionApi,
+        github_client: GitHubClient,
+        *,
+        database_id: str,
+        repo_id_property: str = "Repository ID",
+        repo_page_map: Optional[MutableMapping[str, str]] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._notion = notion_api
+        self._github = github_client
+        self._database_id = database_id
+        self._repo_id_property = repo_id_property
+        self._repo_page_map = repo_page_map if repo_page_map is not None else {}
+        self._logger = logger or LOGGER
+
+    @property
+    def repo_page_map(self) -> MutableMapping[str, str]:
+        return self._repo_page_map
+
+    def sync_repositories(self, *, dry_run: bool = False) -> SyncSummary:
+        summary = SyncSummary()
+        try:
+            repositories = list(self._github.list_repositories())
+        except GitHubApiError as exc:
+            self._logger.error("Failed to list repositories from GitHub: %s", exc)
+            summary.record_failure({"name": "<github>"}, str(exc))
+            return summary
+
+        for repository in repositories:
+            repo_identifier = str(repository.get("id"))
+            context = repository.get("full_name") or repository.get("name") or repo_identifier
+            try:
+                self._sync_single_repository(repository, repo_identifier, dry_run=dry_run)
+            except NotionApiError as exc:
+                self._log_error(context, exc)
+                summary.record_failure(repository, str(exc))
+                continue
+            except Exception as exc:  # pragma: no cover - safety net
+                self._log_error(context, exc)
+                summary.record_failure(repository, str(exc))
+                continue
+
+            summary.record_success()
+
+        return summary
+
+    # ------------------------------------------------------------------
+    def _log_error(self, context: str, exc: Exception) -> None:
+        self._logger.error("Notion sync failed for %s: %s", context, exc)
+
+    def _sync_single_repository(
+        self,
+        repository: Mapping[str, object],
+        repo_identifier: str,
+        *,
+        dry_run: bool,
+    ) -> None:
+        payload = mappers.build_page_payload(
+            repository,
+            database_id=self._database_id,
+            repo_id_property=self._repo_id_property,
+        )
+        existing_page_id = self._resolve_page_id(repo_identifier, repository)
+
+        if dry_run:
+            self._logger.info(
+                "Dry run enabled; skipping sync for %s", repository.get("full_name") or repository.get("name")
+            )
+            return
+
+        if existing_page_id:
+            self._notion.update_page(existing_page_id, payload["properties"])
+            self._logger.debug("Updated Notion page %s for repo %s", existing_page_id, repo_identifier)
+        else:
+            page = self._notion.create_page(payload)
+            existing_page_id = str(page.get("id"))
+            self._repo_page_map[repo_identifier] = existing_page_id
+            self._logger.debug("Created Notion page %s for repo %s", existing_page_id, repo_identifier)
+
+        if existing_page_id:
+            self._repo_page_map[repo_identifier] = existing_page_id
+
+    def _resolve_page_id(self, repo_identifier: str, repository: Mapping[str, object]) -> Optional[str]:
+        page_id = self._repo_page_map.get(repo_identifier)
+        if page_id:
+            return page_id
+
+        filter_body = {
+            "property": self._repo_id_property,
+            "rich_text": {
+                "equals": repo_identifier,
+            },
+        }
+        result = self._notion.query_database(self._database_id, filter_body)
+        results = result.get("results", [])
+        if results:
+            page_id = str(results[0].get("id"))
+            self._repo_page_map[repo_identifier] = page_id
+        return page_id

--- a/src/agent_logic/notion_sync/mappers.py
+++ b/src/agent_logic/notion_sync/mappers.py
@@ -1,0 +1,93 @@
+"""Mapping helpers for building Notion payloads."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Mapping, Optional
+
+
+def _rich_text(content: Optional[str]) -> Dict[str, List[Dict[str, Dict[str, str]]]]:
+    text = content or ""
+    return {
+        "rich_text": [
+            {
+                "text": {
+                    "content": text,
+                }
+            }
+        ]
+    }
+
+
+def build_page_payload(
+    repository: Mapping[str, object],
+    *,
+    database_id: str,
+    repo_id_property: str,
+) -> Dict[str, object]:
+    """Create the Notion request payload for a repository.
+
+    Parameters
+    ----------
+    repository:
+        Mapping containing GitHub repository metadata. The following keys are
+        recognised: ``id``, ``name``, ``full_name``, ``html_url``, ``topics``,
+        ``description`` and ``pushed_at``.
+    database_id:
+        The identifier of the Notion database that should receive the page.
+    repo_id_property:
+        Name of the property that stores the GitHub repository identifier.
+    """
+
+    repo_id = str(repository.get("id", ""))
+    name = repository.get("name") or repository.get("full_name") or repo_id
+    description = repository.get("description") or ""
+    html_url = repository.get("html_url") or ""
+    topics = repository.get("topics") or []
+    pushed_at = repository.get("pushed_at")
+
+    last_push = None
+    if pushed_at:
+        if isinstance(pushed_at, datetime):
+            last_push = pushed_at.isoformat()
+        else:
+            last_push = str(pushed_at)
+
+    properties: Dict[str, object] = {
+        "Name": {
+            "title": [
+                {
+                    "text": {
+                        "content": str(name),
+                    }
+                }
+            ]
+        },
+        repo_id_property: _rich_text(repo_id),
+        "Repository": {
+            "url": str(html_url) if html_url else None,
+        },
+        "Description": _rich_text(description),
+    }
+
+    if last_push:
+        properties["Last Push"] = {
+            "date": {
+                "start": last_push,
+            }
+        }
+
+    if topics:
+        properties["Topics"] = {
+            "multi_select": [
+                {"name": str(topic)}
+                for topic in topics
+                if str(topic).strip()
+            ]
+        }
+
+    payload: Dict[str, object] = {
+        "parent": {"database_id": database_id},
+        "properties": properties,
+    }
+
+    return payload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/notion_sync/test_client.py
+++ b/tests/notion_sync/test_client.py
@@ -1,0 +1,135 @@
+import logging
+from typing import Dict, List
+
+import pytest
+
+from agent_logic.notion_sync.client import GitHubApiError, NotionApiError, NotionSyncClient
+
+
+class DummyNotionAPI:
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.created: List[Dict[str, object]] = []
+        self.updated: List[Dict[str, object]] = []
+        self.queries: List[Dict[str, object]] = []
+        self.pages = {}
+
+    def query_database(self, database_id: str, filter_body: Dict[str, object]):
+        self.queries.append({"database_id": database_id, "filter": filter_body})
+        repo_id = filter_body["rich_text"]["equals"]
+        if repo_id in self.pages:
+            return {"results": [{"id": self.pages[repo_id]}]}
+        return {"results": []}
+
+    def create_page(self, payload: Dict[str, object]):
+        if self.should_fail:
+            raise NotionApiError("create failed")
+        new_id = f"page-{len(self.created) + 1}"
+        repo_id = payload["properties"]["Repository ID"]["rich_text"][0]["text"]["content"]
+        self.pages[repo_id] = new_id
+        self.created.append(payload)
+        return {"id": new_id}
+
+    def update_page(self, page_id: str, properties: Dict[str, object]):
+        if self.should_fail:
+            raise NotionApiError("update failed")
+        self.updated.append({"page_id": page_id, "properties": properties})
+
+
+class DummyGitHubClient:
+    def __init__(self, repositories: List[Dict[str, object]], *, should_fail: bool = False) -> None:
+        self.repositories = repositories
+        self.should_fail = should_fail
+
+    def list_repositories(self):
+        if self.should_fail:
+            raise GitHubApiError("boom")
+        return self.repositories
+
+
+@pytest.fixture
+def repositories():
+    return [
+        {
+            "id": 1,
+            "name": "first",
+            "full_name": "org/first",
+            "html_url": "https://github.com/org/first",
+            "description": "First repository",
+            "topics": ["alpha"],
+        },
+        {
+            "id": 2,
+            "name": "second",
+            "full_name": "org/second",
+            "html_url": "https://github.com/org/second",
+            "description": "Second repository",
+            "topics": ["beta"],
+        },
+    ]
+
+
+def test_sync_repositories_success(repositories):
+    notion = DummyNotionAPI()
+    github = DummyGitHubClient(repositories)
+    client = NotionSyncClient(notion, github, database_id="db1")
+
+    summary = client.sync_repositories()
+
+    assert summary.processed == 2
+    assert summary.failed == 0
+    assert len(notion.created) == 2
+    assert client.repo_page_map == {"1": "page-1", "2": "page-2"}
+
+
+def test_sync_repositories_updates_existing(repositories):
+    notion = DummyNotionAPI()
+    notion.pages["1"] = "existing-page"
+    github = DummyGitHubClient(repositories)
+    cache = {"1": "existing-page"}
+    client = NotionSyncClient(notion, github, database_id="db1", repo_page_map=cache)
+
+    summary = client.sync_repositories()
+
+    assert summary.failed == 0
+    assert notion.updated[0]["page_id"] == "existing-page"
+    assert client.repo_page_map["1"] == "existing-page"
+
+
+def test_sync_repositories_dry_run_skips_writes(repositories, caplog):
+    notion = DummyNotionAPI()
+    github = DummyGitHubClient(repositories)
+    client = NotionSyncClient(notion, github, database_id="db1")
+
+    with caplog.at_level(logging.INFO):
+        summary = client.sync_repositories(dry_run=True)
+
+    assert summary.succeeded == 2
+    assert not notion.created
+    assert "Dry run enabled" in caplog.text
+
+
+def test_sync_repositories_handles_notion_errors(repositories, caplog):
+    notion = DummyNotionAPI(should_fail=True)
+    github = DummyGitHubClient(repositories)
+    client = NotionSyncClient(notion, github, database_id="db1")
+
+    with caplog.at_level(logging.ERROR):
+        summary = client.sync_repositories()
+
+    assert summary.failed == 2
+    assert "Notion sync failed" in caplog.text
+    assert len(summary.errors) == 2
+
+
+def test_sync_repositories_handles_github_errors(caplog):
+    notion = DummyNotionAPI()
+    github = DummyGitHubClient([], should_fail=True)
+    client = NotionSyncClient(notion, github, database_id="db1")
+
+    with caplog.at_level(logging.ERROR):
+        summary = client.sync_repositories()
+
+    assert summary.failed == 1
+    assert summary.processed == 1
+    assert "Failed to list repositories" in caplog.text

--- a/tests/notion_sync/test_mappers.py
+++ b/tests/notion_sync/test_mappers.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from agent_logic.notion_sync import mappers
+
+
+@pytest.fixture
+def repository_payload():
+    return {
+        "id": 42,
+        "name": "demo",
+        "full_name": "pr-cybr/demo",
+        "html_url": "https://github.com/pr-cybr/demo",
+        "topics": ["automation", "integration"],
+        "description": "Sample repository",
+        "pushed_at": datetime(2024, 4, 1, 12, 30, 0),
+    }
+
+
+def test_build_page_payload(repository_payload):
+    payload = mappers.build_page_payload(
+        repository_payload,
+        database_id="abc123",
+        repo_id_property="Repository ID",
+    )
+
+    assert payload["parent"] == {"database_id": "abc123"}
+    props = payload["properties"]
+    assert props["Name"]["title"][0]["text"]["content"] == "demo"
+    assert props["Repository ID"]["rich_text"][0]["text"]["content"] == "42"
+    assert props["Repository"]["url"] == "https://github.com/pr-cybr/demo"
+    assert props["Description"]["rich_text"][0]["text"]["content"] == "Sample repository"
+    assert props["Last Push"]["date"]["start"] == "2024-04-01T12:30:00"
+    topic_names = {topic["name"] for topic in props["Topics"]["multi_select"]}
+    assert topic_names == {"automation", "integration"}
+
+
+def test_build_page_payload_handles_missing_optionals(repository_payload):
+    repository_payload.update({
+        "topics": [],
+        "description": None,
+        "html_url": None,
+        "pushed_at": None,
+    })
+
+    payload = mappers.build_page_payload(
+        repository_payload,
+        database_id="abc123",
+        repo_id_property="Repo",
+    )
+
+    props = payload["properties"]
+    assert "Topics" not in props
+    assert "Last Push" not in props
+    assert props["Repo"]["rich_text"][0]["text"]["content"] == "42"
+    assert props["Repository"]["url"] is None
+    assert props["Description"]["rich_text"][0]["text"]["content"] == ""


### PR DESCRIPTION
## Summary
- add a Notion synchronisation client and CLI with centralised error handling and dry-run support
- provide payload mapping helpers and unit tests covering payloads, error paths, and identifier caching
- introduce a staged GitHub Actions workflow that validates in staging with minimal token permissions before optional promotion
- declare requests/pytest dependencies and ensure tests can import project modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fc34a0b9b4832387a49e364a9e2ea9