### PR TITLE
Add automation workflows for GitHub↔Notion synchronization

### DIFF
--- a/.github/docs/WORKFLOWS.md
+++ b/.github/docs/WORKFLOWS.md
@@ -1,0 +1,97 @@
+# Notion Synchronisation Workflows
+
+This repository contains a suite of GitHub Actions that keep the agent's Notion
+databases aligned with GitHub activity. Each workflow can operate in dry-run
+mode (set the repository variable `NOTION_SYNC_DRY_RUN` to `true`) while
+credentials are being provisioned. When the required secrets are present the
+workflows perform live updates to the mapped Notion databases.
+
+All workflows rely on the following shared secrets:
+
+- `NOTION_TOKEN` – API token for the Notion integration.
+- `GITHUB_TOKEN` – token with read access to issues, pull requests and
+  workflows.
+
+Additional database identifiers are provided via secrets using the
+`A_*_DB_ID` naming convention (for example `A_TASK_DB_ID`). The values are
+managed centrally in Terraform Cloud and exposed to the repository via secrets.
+
+## Notion Task Sync (`.github/workflows/notion-task-sync.yml`)
+
+- **Triggers**: push (non-main branches), pull request lifecycle events,
+  issue lifecycle events, manual dispatch.
+- **Purpose**: mirrors GitHub issues labelled as tasks into the Notion task
+  database. The workflow filters issues for labels containing the word
+  "task" unless a custom label list is provided through the `--task-labels`
+  argument.
+- **Secrets & Variables**:
+  - `A_TASK_DB_ID` – Notion task database ID.
+  - `NOTION_SYNC_DRY_RUN` (repository variable, optional) – run without
+    writing changes.
+- **Implementation**: executes `python -m agent_logic.notion_sync.sync_entities
+  tasks` which fetches candidate issues through the GitHub REST API and upserts
+  them into Notion via the Notion REST API.
+
+## Notion Pull Request Sync (`.github/workflows/notion-pr-sync.yml`)
+
+- **Triggers**: push (non-main branches), pull request events, manual dispatch.
+- **Purpose**: maintains a record of pull requests—including state, author and
+  reviewer metadata—in the Notion pull request database.
+- **Secrets & Variables**:
+  - `A_PR_DB_ID` – Notion pull-request database ID.
+  - `NOTION_SYNC_DRY_RUN` – optional dry-run control.
+- **Implementation**: runs `python -m agent_logic.notion_sync.sync_entities
+  pull_requests` to aggregate PR data and synchronise it to Notion.
+
+## Notion Issue Sync (`.github/workflows/notion-issues-sync.yml`)
+
+- **Triggers**: push (non-main branches), issue lifecycle events, manual
+  dispatch.
+- **Purpose**: keeps the canonical Notion issue backlog aligned with the state
+  of GitHub issues.
+- **Secrets & Variables**:
+  - `A_ISSUES_DB_ID` – Notion issues database ID.
+  - `NOTION_SYNC_DRY_RUN` – optional dry-run control.
+- **Implementation**: runs `python -m agent_logic.notion_sync.sync_entities
+  issues` to capture issue metadata (labels, assignees, timestamps) and upsert
+  it into Notion.
+
+## Notion Project Sync (`.github/workflows/notion-project-sync.yml`)
+
+- **Triggers**: push (non-main branches), GitHub milestone and project events,
+  manual dispatch.
+- **Purpose**: synchronises repository milestones and classic projects to the
+  Notion project tracking database, capturing dates, descriptions and issue
+  counts.
+- **Secrets & Variables**:
+  - `A_PROJECTS_DB_ID` – Notion project database ID.
+  - `NOTION_SYNC_DRY_RUN` – optional dry-run control.
+- **Implementation**: executes `python -m agent_logic.notion_sync.sync_entities
+  projects` which queries milestones and repository projects, then upserts the
+  combined dataset into Notion.
+
+## Notion Runs Board Sync (`.github/workflows/notion-runs-sync.yml`)
+
+- **Triggers**: completion of core automation workflows (including the four
+  Notion sync pipelines, Terraform, maintenance and Docker builds), manual
+  dispatch.
+- **Purpose**: provides an audit trail of automation runs in Notion by
+  capturing workflow name, status, branch, SHA and timestamps.
+- **Secrets & Variables**:
+  - `A_RUNS_BOARD_ID` – Notion runs/audit database ID.
+  - `NOTION_SYNC_DRY_RUN` – optional dry-run control.
+- **Implementation**: when triggered by a `workflow_run` event the workflow
+  invokes `python -m agent_logic.notion_sync.sync_entities runs`, which reads
+  the GitHub event payload (`GITHUB_EVENT_PATH`) and upserts a single run
+  record into Notion.
+
+## Operational Notes
+
+- Execute the existing `Verify Environment Variables` workflow whenever
+  secrets are updated to confirm that required credentials are available to the
+  pipelines.
+- The synchronisation scripts automatically inspect Notion database schemas and
+  only populate properties that already exist, reducing the risk of runtime
+  errors when database schemas change.
+- To onboard a new database, populate the matching secret (`A_*_DB_ID`) and
+  allow the automation to run on the next relevant GitHub event.

--- a/.github/workflows/notion-issues-sync.yml
+++ b/.github/workflows/notion-issues-sync.yml
@@ -1,0 +1,69 @@
+name: Notion Issue Sync
+
+on:
+  push:
+    branches:
+      - "staging/**"
+      - "dev/**"
+      - "feature/**"
+      - "hotfix/**"
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: notion-issues-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync issues to Notion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise issues to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_ISSUES_DB_ID: ${{ secrets.A_ISSUES_DB_ID }}
+          NOTION_SYNC_DRY_RUN: ${{ vars.NOTION_SYNC_DRY_RUN }}
+        run: |
+          if [ -z "${NOTION_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${NOTION_ISSUES_DB_ID}" ]; then
+            echo "Notion issue sync skipped because required secrets are not configured."
+            exit 0
+          fi
+          DRY_RUN_FLAG=""
+          if [ "${NOTION_SYNC_DRY_RUN}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m agent_logic.notion_sync.sync_entities issues \
+            --database-id "${NOTION_ISSUES_DB_ID}" \
+            --repo "${{ github.repository }}" \
+            --unique-property "GitHub ID" \
+            ${DRY_RUN_FLAG}

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -1,0 +1,66 @@
+name: Notion Pull Request Sync
+
+on:
+  push:
+    branches:
+      - "staging/**"
+      - "dev/**"
+      - "feature/**"
+      - "hotfix/**"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: notion-pr-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync pull requests to Notion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise pull requests to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_PR_DB_ID: ${{ secrets.A_PR_DB_ID }}
+          NOTION_SYNC_DRY_RUN: ${{ vars.NOTION_SYNC_DRY_RUN }}
+        run: |
+          if [ -z "${NOTION_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${NOTION_PR_DB_ID}" ]; then
+            echo "Notion pull request sync skipped because required secrets are not configured."
+            exit 0
+          fi
+          DRY_RUN_FLAG=""
+          if [ "${NOTION_SYNC_DRY_RUN}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m agent_logic.notion_sync.sync_entities pull_requests \
+            --database-id "${NOTION_PR_DB_ID}" \
+            --repo "${{ github.repository }}" \
+            --unique-property "GitHub ID" \
+            ${DRY_RUN_FLAG}

--- a/.github/workflows/notion-project-sync.yml
+++ b/.github/workflows/notion-project-sync.yml
@@ -1,0 +1,73 @@
+name: Notion Project Sync
+
+on:
+  push:
+    branches:
+      - "staging/**"
+      - "dev/**"
+      - "feature/**"
+      - "hotfix/**"
+  milestone:
+    types:
+      - created
+      - closed
+      - opened
+      - edited
+  project:
+    types:
+      - created
+      - deleted
+      - edited
+      - closed
+      - reopened
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  projects: read
+
+concurrency:
+  group: notion-project-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync project data to Notion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise project data to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_PROJECTS_DB_ID: ${{ secrets.A_PROJECTS_DB_ID }}
+          NOTION_SYNC_DRY_RUN: ${{ vars.NOTION_SYNC_DRY_RUN }}
+        run: |
+          if [ -z "${NOTION_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${NOTION_PROJECTS_DB_ID}" ]; then
+            echo "Notion project sync skipped because required secrets are not configured."
+            exit 0
+          fi
+          DRY_RUN_FLAG=""
+          if [ "${NOTION_SYNC_DRY_RUN}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m agent_logic.notion_sync.sync_entities projects \
+            --database-id "${NOTION_PROJECTS_DB_ID}" \
+            --repo "${{ github.repository }}" \
+            --unique-property "GitHub ID" \
+            ${DRY_RUN_FLAG}

--- a/.github/workflows/notion-runs-sync.yml
+++ b/.github/workflows/notion-runs-sync.yml
@@ -1,0 +1,66 @@
+name: Notion Runs Board Sync
+
+on:
+  workflow_run:
+    workflows:
+      - Notion Task Sync
+      - Notion Pull Request Sync
+      - Notion Issue Sync
+      - Notion Project Sync
+      - Notion Synchronisation Pipeline
+      - maintenance
+      - tfc-sync
+      - Build and Publish image to Docker Hub
+      - Verify Environment Variables
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: notion-runs-sync-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    if: ${{ github.event.workflow_run.conclusion != '' }}
+    name: Log workflow execution to Notion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Record workflow run in Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_RUNS_DB_ID: ${{ secrets.A_RUNS_BOARD_ID }}
+          NOTION_SYNC_DRY_RUN: ${{ vars.NOTION_SYNC_DRY_RUN }}
+        run: |
+          if [ -z "${NOTION_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${NOTION_RUNS_DB_ID}" ]; then
+            echo "Notion runs board sync skipped because required secrets are not configured."
+            exit 0
+          fi
+          DRY_RUN_FLAG=""
+          if [ "${NOTION_SYNC_DRY_RUN}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m agent_logic.notion_sync.sync_entities runs \
+            --database-id "${NOTION_RUNS_DB_ID}" \
+            --unique-property "GitHub ID" \
+            ${DRY_RUN_FLAG}

--- a/.github/workflows/notion-task-sync.yml
+++ b/.github/workflows/notion-task-sync.yml
@@ -1,0 +1,76 @@
+name: Notion Task Sync
+
+on:
+  push:
+    branches:
+      - "staging/**"
+      - "dev/**"
+      - "feature/**"
+      - "hotfix/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: notion-task-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync tasks to Notion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise tasks to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TASK_DB_ID: ${{ secrets.A_TASK_DB_ID }}
+          NOTION_SYNC_DRY_RUN: ${{ vars.NOTION_SYNC_DRY_RUN }}
+        run: |
+          if [ -z "${NOTION_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${NOTION_TASK_DB_ID}" ]; then
+            echo "Notion task sync skipped because required secrets are not configured."
+            exit 0
+          fi
+          DRY_RUN_FLAG=""
+          if [ "${NOTION_SYNC_DRY_RUN}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m agent_logic.notion_sync.sync_entities tasks \
+            --database-id "${NOTION_TASK_DB_ID}" \
+            --repo "${{ github.repository }}" \
+            --unique-property "GitHub ID" \
+            ${DRY_RUN_FLAG}

--- a/src/agent_logic/notion_sync/__init__.py
+++ b/src/agent_logic/notion_sync/__init__.py
@@ -2,3 +2,4 @@
 
 from .client import NotionSyncClient, NotionApiError, GitHubApiError, SyncSummary  # noqa: F401
 from . import mappers  # noqa: F401
+from .sync_entities import main as run_entity_sync  # noqa: F401

--- a/src/agent_logic/notion_sync/client.py
+++ b/src/agent_logic/notion_sync/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Mapping, MutableMapping, Optional
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
 
 import requests
 
@@ -64,6 +64,15 @@ class NotionApi:
         )
         if response.status_code >= 400:
             raise NotionApiError(f"Failed to query Notion database: {response.text}")
+        return response.json()
+
+    def retrieve_database(self, database_id: str) -> Mapping[str, object]:
+        response = self._session.get(
+            f"{self._base_url}/databases/{database_id}",
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise NotionApiError(f"Failed to retrieve Notion database: {response.text}")
         return response.json()
 
     def create_page(self, payload: Mapping[str, object]) -> Mapping[str, object]:

--- a/src/agent_logic/notion_sync/entities.py
+++ b/src/agent_logic/notion_sync/entities.py
@@ -1,0 +1,567 @@
+"""Utilities for synchronising GitHub entities with Notion databases."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import requests
+
+from .client import GitHubApiError, NotionApi, NotionApiError, SyncSummary
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helper structures
+
+
+@dataclass(frozen=True)
+class PropertyValue:
+    """Container for describing a Notion property update."""
+
+    value: object
+    preferred_types: Sequence[str]
+
+    @classmethod
+    def text(cls, value: Optional[str]) -> "PropertyValue":
+        return cls(value or "", ("rich_text", "title"))
+
+    @classmethod
+    def url(cls, value: Optional[str]) -> "PropertyValue":
+        return cls(value or "", ("url", "rich_text"))
+
+    @classmethod
+    def status(cls, value: Optional[str]) -> "PropertyValue":
+        return cls(value or "", ("status", "select", "rich_text"))
+
+    @classmethod
+    def multi_select(cls, values: Sequence[str]) -> "PropertyValue":
+        return cls(list(values), ("multi_select", "rich_text"))
+
+    @classmethod
+    def number(cls, value: Optional[float]) -> "PropertyValue":
+        return cls(value, ("number", "rich_text"))
+
+    @classmethod
+    def date(cls, value: Optional[str]) -> "PropertyValue":
+        return cls(value, ("date", "rich_text"))
+
+
+@dataclass
+class NotionRecord:
+    """Represents a single entry that should exist inside a Notion database."""
+
+    unique_id: str
+    name: str
+    properties: Mapping[str, PropertyValue]
+
+
+def _truncate_text(value: str, *, limit: int = 1900) -> str:
+    if len(value) <= limit:
+        return value
+    return f"{value[: limit - 3]}..."
+
+
+class EntitySyncEngine:
+    """Generic synchroniser that can upsert records into a Notion database."""
+
+    def __init__(
+        self,
+        notion_api: NotionApi,
+        *,
+        database_id: str,
+        unique_property: str = "GitHub ID",
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._notion = notion_api
+        self._database_id = database_id
+        self._unique_property = unique_property
+        self._logger = logger or LOGGER
+        self._database_schema = self._load_database_schema()
+        self._title_property = self._find_title_property()
+        self._unique_schema = self._database_schema.get(unique_property)
+        self._page_cache: MutableMapping[str, str] = {}
+
+    # ------------------------------------------------------------------
+    def _load_database_schema(self) -> Mapping[str, Mapping[str, object]]:
+        database = self._notion.retrieve_database(self._database_id)
+        properties = database.get("properties", {})
+        if not isinstance(properties, Mapping):
+            raise NotionApiError("Unable to read Notion database properties")
+        return properties  # type: ignore[return-value]
+
+    def _find_title_property(self) -> str:
+        for name, schema in self._database_schema.items():
+            if isinstance(schema, Mapping) and schema.get("type") == "title":
+                return name
+        raise NotionApiError(
+            "Target Notion database does not contain a title property"
+        )
+
+    # ------------------------------------------------------------------
+    def sync(self, records: Iterable[NotionRecord], *, dry_run: bool = False) -> SyncSummary:
+        summary = SyncSummary()
+        for record in records:
+            try:
+                self._sync_single(record, dry_run=dry_run)
+            except Exception as exc:  # pragma: no cover - resiliency guard
+                self._logger.error("Failed to sync %s: %s", record.unique_id, exc)
+                summary.record_failure({"id": record.unique_id}, str(exc))
+                continue
+            summary.record_success()
+        return summary
+
+    def _sync_single(self, record: NotionRecord, *, dry_run: bool) -> None:
+        page_payload = self._build_payload(record)
+        if dry_run:
+            self._logger.info(
+                "Dry-run enabled; skipping update for %s", record.unique_id
+            )
+            return
+
+        page_id = self._resolve_page_id(record.unique_id)
+        if page_id:
+            self._notion.update_page(page_id, page_payload["properties"])
+        else:
+            page = self._notion.create_page(page_payload)
+            page_id = str(page.get("id"))
+        if page_id:
+            self._page_cache[record.unique_id] = page_id
+
+    # ------------------------------------------------------------------
+    def _build_payload(self, record: NotionRecord) -> Mapping[str, object]:
+        properties: Dict[str, object] = {}
+        title_schema = self._database_schema[self._title_property]
+        properties[self._title_property] = self._coerce_property(
+            self._title_property,
+            PropertyValue.text(record.name),
+            title_schema,
+        )
+
+        for name, prop in record.properties.items():
+            if name == self._title_property:
+                continue
+            schema = self._database_schema.get(name)
+            if not schema:
+                continue
+            notion_value = self._coerce_property(name, prop, schema)
+            if notion_value is None:
+                continue
+            properties[name] = notion_value
+
+        return {"parent": {"database_id": self._database_id}, "properties": properties}
+
+    def _coerce_property(
+        self,
+        name: str,
+        prop: PropertyValue,
+        schema: Mapping[str, object],
+    ) -> Optional[Mapping[str, object]]:
+        notion_type = schema.get("type")
+        if notion_type not in prop.preferred_types:
+            if notion_type != "rich_text":
+                return None
+
+        if notion_type == "title":
+            return {
+                "title": [
+                    {
+                        "text": {"content": _truncate_text(str(prop.value))},
+                    }
+                ]
+            }
+        if notion_type == "rich_text":
+            text_value = _truncate_text(str(prop.value))
+            return {"rich_text": [{"text": {"content": text_value}}]}
+        if notion_type == "url":
+            return {"url": str(prop.value) if prop.value else None}
+        if notion_type == "number":
+            if prop.value in (None, ""):
+                return {"number": None}
+            try:
+                return {"number": float(prop.value)}
+            except (TypeError, ValueError):
+                return None
+        if notion_type == "multi_select":
+            values = prop.value or []
+            if not isinstance(values, (list, tuple)):
+                values = [str(values)]
+            return {"multi_select": [{"name": str(v)} for v in values if v]}
+        if notion_type == "status":
+            return self._build_status(schema, prop.value)
+        if notion_type == "select":
+            return self._build_select(schema, prop.value)
+        if notion_type == "date":
+            if not prop.value:
+                return {"date": None}
+            return {"date": {"start": str(prop.value)}}
+        return None
+
+    def _build_status(
+        self, schema: Mapping[str, object], value: object
+    ) -> Optional[Mapping[str, object]]:
+        if not value:
+            return None
+        options = schema.get("status", {}).get("options", [])
+        allowed = {opt.get("name") for opt in options if isinstance(opt, Mapping)}
+        if allowed and str(value) not in allowed:
+            return None
+        return {"status": {"name": str(value)}}
+
+    def _build_select(
+        self, schema: Mapping[str, object], value: object
+    ) -> Optional[Mapping[str, object]]:
+        if not value:
+            return None
+        options = schema.get("select", {}).get("options", [])
+        allowed = {opt.get("name") for opt in options if isinstance(opt, Mapping)}
+        if allowed and str(value) not in allowed:
+            return None
+        return {"select": {"name": str(value)}}
+
+    # ------------------------------------------------------------------
+    def _resolve_page_id(self, unique_id: str) -> Optional[str]:
+        if unique_id in self._page_cache:
+            return self._page_cache[unique_id]
+        if not self._unique_schema:
+            return None
+        filter_body = self._build_unique_filter(unique_id)
+        if filter_body is None:
+            return None
+        result = self._notion.query_database(self._database_id, filter_body)
+        results = result.get("results", [])
+        if results:
+            page_id = str(results[0].get("id"))
+            self._page_cache[unique_id] = page_id
+            return page_id
+        return None
+
+    def _build_unique_filter(self, unique_id: str) -> Optional[Mapping[str, object]]:
+        notion_type = self._unique_schema.get("type") if self._unique_schema else None
+        if notion_type == "rich_text":
+            return {
+                "property": self._unique_property,
+                "rich_text": {"equals": unique_id},
+            }
+        if notion_type == "title":
+            return {
+                "property": self._unique_property,
+                "title": {"equals": unique_id},
+            }
+        if notion_type == "number":
+            try:
+                number_value = float(unique_id)
+            except ValueError:
+                return None
+            return {
+                "property": self._unique_property,
+                "number": {"equals": number_value},
+            }
+        if notion_type == "url":
+            return {
+                "property": self._unique_property,
+                "url": {"equals": unique_id},
+            }
+        return None
+
+
+# ---------------------------------------------------------------------------
+# GitHub data fetcher
+
+
+class GitHubDataFetcher:
+    """Collects data from the GitHub REST API for synchronisation."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        repository: str,
+        api_url: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        if not repository or "/" not in repository:
+            raise ValueError("Repository must be in the form 'owner/name'")
+        self._repository = repository
+        base_url = (api_url or os.environ.get("GITHUB_API_URL") or "https://api.github.com").rstrip("/")
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            }
+        )
+        # Project APIs currently require a preview header.
+        self._project_headers = {
+            "Accept": "application/vnd.github.inertia-preview+json",
+        }
+        self._base_url = base_url
+        self._logger = logger or LOGGER
+
+    # ------------------------------------------------------------------
+    def fetch_task_issues(self, *, labels: Optional[Sequence[str]] = None) -> List[Mapping[str, object]]:
+        issues = self._list_repository_issues(state="all")
+        filtered: List[Mapping[str, object]] = []
+        lowered = [label.lower() for label in labels] if labels else []
+        for issue in issues:
+            if issue.get("pull_request"):
+                continue
+            issue_labels = [str(l.get("name", "")).lower() for l in issue.get("labels", [])]
+            if labels:
+                if not any(label in issue_labels for label in lowered):
+                    continue
+            else:
+                if not any("task" in label for label in issue_labels):
+                    continue
+            filtered.append(issue)
+        return filtered
+
+    def fetch_issues(self) -> List[Mapping[str, object]]:
+        issues = self._list_repository_issues(state="all")
+        return [issue for issue in issues if not issue.get("pull_request")]
+
+    def fetch_pull_requests(self) -> List[Mapping[str, object]]:
+        owner, name = self._repository.split("/")
+        url = f"{self._base_url}/repos/{owner}/{name}/pulls"
+        params = {"state": "all", "per_page": 100}
+        data = self._paginate(url, params=params)
+        return data
+
+    def fetch_milestones(self) -> List[Mapping[str, object]]:
+        owner, name = self._repository.split("/")
+        url = f"{self._base_url}/repos/{owner}/{name}/milestones"
+        params = {"state": "all", "per_page": 100}
+        return self._paginate(url, params=params)
+
+    def fetch_projects(self) -> List[Mapping[str, object]]:
+        owner, name = self._repository.split("/")
+        url = f"{self._base_url}/repos/{owner}/{name}/projects"
+        params = {"state": "all", "per_page": 100}
+        try:
+            return self._paginate(url, params=params, extra_headers=self._project_headers)
+        except GitHubApiError as exc:
+            # Some repositories disable projects; treat this as non-fatal.
+            if "410" in str(exc) or "404" in str(exc):
+                self._logger.debug("Repository projects unavailable: %s", exc)
+                return []
+            raise
+
+    # ------------------------------------------------------------------
+    def _list_repository_issues(self, *, state: str = "open") -> List[Mapping[str, object]]:
+        owner, name = self._repository.split("/")
+        url = f"{self._base_url}/repos/{owner}/{name}/issues"
+        params = {"state": state, "per_page": 100}
+        return self._paginate(url, params=params)
+
+    def _paginate(
+        self,
+        url: str,
+        *,
+        params: Optional[Mapping[str, object]] = None,
+        extra_headers: Optional[Mapping[str, str]] = None,
+    ) -> List[Mapping[str, object]]:
+        results: List[Mapping[str, object]] = []
+        headers = dict(self._session.headers)
+        if extra_headers:
+            headers.update(extra_headers)
+        while url:
+            response = self._session.get(url, params=params, headers=headers, timeout=30)
+            if response.status_code >= 400:
+                raise GitHubApiError(
+                    f"GitHub API error ({response.status_code}): {response.text}"
+                )
+            payload = response.json()
+            if isinstance(payload, list):
+                results.extend(payload)
+            else:
+                results.append(payload)
+            url = response.links.get("next", {}).get("url")
+            params = None
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Record builders
+
+
+def build_task_records(issues: Sequence[Mapping[str, object]]) -> List[NotionRecord]:
+    records: List[NotionRecord] = []
+    for issue in issues:
+        labels = [label.get("name", "") for label in issue.get("labels", [])]
+        assignees = [assignee.get("login", "") for assignee in issue.get("assignees", [])]
+        properties: Dict[str, PropertyValue] = {
+            "GitHub ID": PropertyValue.text(str(issue.get("id"))),
+            "GitHub URL": PropertyValue.url(issue.get("html_url")),
+            "Status": PropertyValue.status(str(issue.get("state", "")).title()),
+            "Labels": PropertyValue.multi_select([label for label in labels if label]),
+            "Assignees": PropertyValue.text(", ".join([a for a in assignees if a]) or "Unassigned"),
+            "Created": PropertyValue.date(issue.get("created_at")),
+            "Updated": PropertyValue.date(issue.get("updated_at")),
+        }
+        if issue.get("closed_at"):
+            properties["Completed"] = PropertyValue.date(issue.get("closed_at"))
+        properties["Summary"] = PropertyValue.text(issue.get("title"))
+        records.append(
+            NotionRecord(
+                unique_id=str(issue.get("id")),
+                name=str(issue.get("title", "Task")),
+                properties=properties,
+            )
+        )
+    return records
+
+
+def build_issue_records(issues: Sequence[Mapping[str, object]]) -> List[NotionRecord]:
+    records: List[NotionRecord] = []
+    for issue in issues:
+        labels = [label.get("name", "") for label in issue.get("labels", [])]
+        assignees = [assignee.get("login", "") for assignee in issue.get("assignees", [])]
+        properties: Dict[str, PropertyValue] = {
+            "GitHub ID": PropertyValue.text(str(issue.get("id"))),
+            "GitHub URL": PropertyValue.url(issue.get("html_url")),
+            "Status": PropertyValue.status(str(issue.get("state", "")).title()),
+            "Labels": PropertyValue.multi_select([label for label in labels if label]),
+            "Assignees": PropertyValue.text(", ".join([a for a in assignees if a]) or "Unassigned"),
+            "Created": PropertyValue.date(issue.get("created_at")),
+            "Updated": PropertyValue.date(issue.get("updated_at")),
+            "Summary": PropertyValue.text(issue.get("title")),
+        }
+        if issue.get("closed_at"):
+            properties["Closed"] = PropertyValue.date(issue.get("closed_at"))
+        records.append(
+            NotionRecord(
+                unique_id=str(issue.get("id")),
+                name=str(issue.get("title", "Issue")),
+                properties=properties,
+            )
+        )
+    return records
+
+
+def build_pr_records(pull_requests: Sequence[Mapping[str, object]]) -> List[NotionRecord]:
+    records: List[NotionRecord] = []
+    for pr in pull_requests:
+        labels = [label.get("name", "") for label in pr.get("labels", [])]
+        author = pr.get("user", {}).get("login") if isinstance(pr.get("user"), Mapping) else None
+        reviewers = pr.get("requested_reviewers", []) or []
+        reviewer_names = [reviewer.get("login", "") for reviewer in reviewers]
+        merged_at = pr.get("merged_at")
+        state = str(pr.get("state", "")).title()
+        if merged_at:
+            state = "Merged"
+        properties: Dict[str, PropertyValue] = {
+            "GitHub ID": PropertyValue.text(str(pr.get("id"))),
+            "GitHub URL": PropertyValue.url(pr.get("html_url")),
+            "Status": PropertyValue.status(state),
+            "Author": PropertyValue.text(author or "unknown"),
+            "Labels": PropertyValue.multi_select([label for label in labels if label]),
+            "Reviewers": PropertyValue.text(", ".join([r for r in reviewer_names if r]) or "None"),
+            "Created": PropertyValue.date(pr.get("created_at")),
+            "Updated": PropertyValue.date(pr.get("updated_at")),
+        }
+        if merged_at:
+            properties["Completed"] = PropertyValue.date(merged_at)
+        records.append(
+            NotionRecord(
+                unique_id=str(pr.get("id")),
+                name=str(pr.get("title", "Pull Request")),
+                properties=properties,
+            )
+        )
+    return records
+
+
+def build_project_records(
+    milestones: Sequence[Mapping[str, object]],
+    projects: Sequence[Mapping[str, object]],
+) -> List[NotionRecord]:
+    records: List[NotionRecord] = []
+    for milestone in milestones:
+        properties: Dict[str, PropertyValue] = {
+            "GitHub ID": PropertyValue.text(str(milestone.get("id"))),
+            "GitHub URL": PropertyValue.url(milestone.get("html_url")),
+            "Status": PropertyValue.status(str(milestone.get("state", "")).title()),
+            "Type": PropertyValue.text("Milestone"),
+            "Due Date": PropertyValue.date(milestone.get("due_on")),
+            "Description": PropertyValue.text(milestone.get("description")),
+            "Open Issues": PropertyValue.number(milestone.get("open_issues")),
+            "Closed Issues": PropertyValue.number(milestone.get("closed_issues")),
+            "Updated": PropertyValue.date(milestone.get("updated_at")),
+            "Created": PropertyValue.date(milestone.get("created_at")),
+        }
+        records.append(
+            NotionRecord(
+                unique_id=str(milestone.get("id")),
+                name=str(milestone.get("title", "Milestone")),
+                properties=properties,
+            )
+        )
+
+    for project in projects:
+        properties = {
+            "GitHub ID": PropertyValue.text(str(project.get("id"))),
+            "GitHub URL": PropertyValue.url(project.get("html_url")),
+            "Status": PropertyValue.status(str(project.get("state", "")).title()),
+            "Type": PropertyValue.text("Project"),
+            "Description": PropertyValue.text(project.get("body")),
+            "Created": PropertyValue.date(project.get("created_at")),
+            "Updated": PropertyValue.date(project.get("updated_at")),
+        }
+        records.append(
+            NotionRecord(
+                unique_id=str(project.get("id")),
+                name=str(project.get("name", "Project")),
+                properties=properties,
+            )
+        )
+
+    return records
+
+
+def build_run_records(run_payload: Mapping[str, object]) -> List[NotionRecord]:
+    workflow_run = run_payload.get("workflow_run") if isinstance(run_payload, Mapping) else None
+    if not isinstance(workflow_run, Mapping):
+        return []
+    run_id = str(workflow_run.get("id"))
+    run_name = str(workflow_run.get("name", "Workflow"))
+    run_number = workflow_run.get("run_number")
+    full_name = f"{run_name} #{run_number}" if run_number else run_name
+    conclusion = workflow_run.get("conclusion") or workflow_run.get("status")
+    properties: Dict[str, PropertyValue] = {
+        "GitHub ID": PropertyValue.text(run_id),
+        "GitHub URL": PropertyValue.url(workflow_run.get("html_url")),
+        "Status": PropertyValue.status(str(workflow_run.get("status", "")).title()),
+        "Conclusion": PropertyValue.status(str(conclusion or "unknown").title()),
+        "Event": PropertyValue.text(workflow_run.get("event")),
+        "Branch": PropertyValue.text(workflow_run.get("head_branch")),
+        "Commit": PropertyValue.text(workflow_run.get("head_sha")),
+        "Run Number": PropertyValue.number(run_number),
+        "Created": PropertyValue.date(workflow_run.get("run_started_at")),
+        "Updated": PropertyValue.date(workflow_run.get("updated_at")),
+    }
+    actor = workflow_run.get("actor")
+    if isinstance(actor, Mapping):
+        properties["Actor"] = PropertyValue.text(actor.get("login"))
+    return [
+        NotionRecord(
+            unique_id=run_id,
+            name=full_name,
+            properties=properties,
+        )
+    ]
+
+
+__all__ = [
+    "EntitySyncEngine",
+    "GitHubDataFetcher",
+    "NotionRecord",
+    "PropertyValue",
+    "build_issue_records",
+    "build_pr_records",
+    "build_project_records",
+    "build_run_records",
+    "build_task_records",
+]
+

--- a/src/agent_logic/notion_sync/sync_entities.py
+++ b/src/agent_logic/notion_sync/sync_entities.py
@@ -1,0 +1,146 @@
+"""Command line entry point for synchronising GitHub entities with Notion."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Iterable, List, Optional, Sequence
+
+from .client import NotionApi, SyncSummary
+from .entities import (
+    EntitySyncEngine,
+    GitHubDataFetcher,
+    build_issue_records,
+    build_pr_records,
+    build_project_records,
+    build_run_records,
+    build_task_records,
+)
+
+
+LOGGER = logging.getLogger("notion_entity_sync")
+
+
+def _get_token(env_var: str) -> str:
+    value = os.environ.get(env_var)
+    if not value:
+        raise SystemExit(f"{env_var} environment variable must be set")
+    return value
+
+
+def _parse_labels(value: Optional[str]) -> Optional[List[str]]:
+    if not value:
+        return None
+    return [label.strip() for label in value.split(",") if label.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synchronise GitHub data with Notion")
+    parser.add_argument(
+        "entity",
+        choices=["tasks", "pull_requests", "issues", "projects", "runs"],
+        help="Entity type to synchronise",
+    )
+    parser.add_argument("--database-id", required=True, help="Target Notion database identifier")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="GitHub repository (owner/name)")
+    parser.add_argument("--task-labels", help="Comma separated labels to treat as tasks")
+    parser.add_argument("--unique-property", default="GitHub ID", help="Notion property used as unique identifier")
+    parser.add_argument("--dry-run", action="store_true", help="Log actions without writing to Notion")
+    parser.add_argument(
+        "--event-path",
+        default=os.environ.get("GITHUB_EVENT_PATH"),
+        help="Path to GitHub event payload (used for workflow_run events)",
+    )
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    return parser
+
+
+def _load_event_payload(path: Optional[str]) -> dict:
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _sync_records(
+    engine: EntitySyncEngine,
+    records: Iterable,
+    *,
+    dry_run: bool,
+) -> SyncSummary:
+    return engine.sync(records, dry_run=dry_run)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    notion_token = _get_token("NOTION_TOKEN")
+    github_token = _get_token("GITHUB_TOKEN")
+
+    notion_api = NotionApi(notion_token)
+
+    engine = EntitySyncEngine(
+        notion_api,
+        database_id=args.database_id,
+        unique_property=args.unique_property,
+        logger=LOGGER,
+    )
+
+    dry_run = args.dry_run
+    summary: SyncSummary
+
+    if args.entity == "runs":
+        payload = _load_event_payload(args.event_path)
+        records = build_run_records(payload)
+        summary = _sync_records(engine, records, dry_run=dry_run)
+        return 0 if not summary.failed else 1
+
+    repository = args.repo
+    if not repository:
+        LOGGER.error("--repo must be provided or GITHUB_REPOSITORY must be set")
+        return 1
+
+    fetcher = GitHubDataFetcher(github_token, repository=repository, logger=LOGGER)
+
+    if args.entity == "tasks":
+        task_labels = _parse_labels(args.task_labels)
+        issues = fetcher.fetch_task_issues(labels=task_labels)
+        records = build_task_records(issues)
+    elif args.entity == "pull_requests":
+        pull_requests = fetcher.fetch_pull_requests()
+        records = build_pr_records(pull_requests)
+    elif args.entity == "issues":
+        issues = fetcher.fetch_issues()
+        records = build_issue_records(issues)
+    elif args.entity == "projects":
+        milestones = fetcher.fetch_milestones()
+        projects = fetcher.fetch_projects()
+        records = build_project_records(milestones, projects)
+    else:  # pragma: no cover - defensive programming
+        parser.error(f"Unsupported entity: {args.entity}")
+        return 2
+
+    summary = _sync_records(engine, records, dry_run=dry_run)
+    if summary.failed:
+        LOGGER.error(
+            "Synchronisation completed with %s failures out of %s records",
+            summary.failed,
+            summary.processed,
+        )
+        return 1
+
+    LOGGER.info(
+        "Synchronisation completed successfully for %s records",
+        summary.succeeded,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- add a reusable Notion entity synchronisation engine and CLI to sync GitHub data sets
- create GitHub Actions workflows for tasks, pull requests, issues, projects, and workflow run logging
- document the new automation in `.github/docs/WORKFLOWS.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe99f78688832398f2e5c7d82d1f79