### PR TITLE
Add GitHub-Notion sync workflows

### DIFF
--- a/.github/docs/WORKFLOWS.md
+++ b/.github/docs/WORKFLOWS.md
@@ -1,0 +1,93 @@
+# Workflow Catalogue
+
+This document summarises the automation pipelines that synchronise GitHub activity
+with the Notion workspace for the PR-CYBR data integration agent. Each workflow is
+implemented in `.github/workflows/` and relies on repository secrets managed by
+Terraform Cloud. The jobs inherit the standard branch promotion strategy defined in
+[spec-bootstrap](https://github.com/PR-CYBR/spec-bootstrap/) and should run only on
+non-production branches unless manually promoted.
+
+> **Secrets and variables**
+>
+> The workflows expect the global `NOTION_TOKEN` secret and a GitHub token (the
+> `AGENT_ACTIONS` secret is preferred, with the fall-back to the default
+> `GITHUB_TOKEN`). Database identifiers are retrieved from secrets if available and
+> otherwise from repository variables. The recommended variable names are noted in
+> each section below. If your environment uses a different secret naming scheme,
+> update the repository variables so that the workflow inputs resolve correctly.
+
+## `.github/workflows/notion-task-sync.yml`
+
+Synchronises GitHub issues labelled as tasks with the Notion task database.
+
+- **Triggers:** any `push`, issue activity (open, edit, assignment, labelling), and
+  `workflow_dispatch` for ad-hoc runs.
+- **Target database:** `${{ secrets.NOTION_TASK_DB_ID }}` or `vars.TASK_DATABASE_ID`.
+- **Defaults:** Task label is `task`, unique key property is `GitHub ID`.
+- **Behaviour:** Invokes `python -m agent_logic.notion_sync.entity_cli tasks` to
+  fetch all labelled issues (excluding pull requests) and mirrors their status,
+  assignees, labels, and completion date to Notion.
+
+## `.github/workflows/notion-pr-sync.yml`
+
+Mirrors pull request metadata to the Notion PR database.
+
+- **Triggers:** `pull_request` events (open, sync, reopen, close) and manual
+  dispatch.
+- **Target database:** `${{ secrets.NOTION_PR_DB_ID }}` or `vars.PR_DATABASE_ID`.
+- **Defaults:** Unique key property is `GitHub ID`.
+- **Behaviour:** Uses `python -m agent_logic.notion_sync.entity_cli pull-requests`
+  to record title, state (`Open`, `Closed`, or `Merged`), authors, reviewers, and
+  merge timestamps.
+
+## `.github/workflows/notion-issue-sync.yml`
+
+Keeps the engineering issue database in Notion aligned with GitHub.
+
+- **Triggers:** issue events (open, edit, close, reopen, label/assign changes) and
+  manual dispatch.
+- **Target database:** `${{ secrets.NOTION_ISSUES_DB_ID }}` or
+  `vars.ISSUE_DATABASE_ID`.
+- **Behaviour:** Runs `python -m agent_logic.notion_sync.entity_cli issues` and
+  captures the state, assignees, labels, and timestamps for every GitHub issue.
+
+## `.github/workflows/notion-project-sync.yml`
+
+Publishes repository milestones to the Notion projects database.
+
+- **Triggers:** any `push` and manual dispatch.
+- **Target database:** `${{ secrets.NOTION_PROJECTS_DB_ID }}` or
+  `vars.PROJECT_DATABASE_ID`.
+- **Behaviour:** Calls `python -m agent_logic.notion_sync.entity_cli projects` to
+  enumerate milestones (treating them as project checkpoints) and sync their due
+  dates, open/closed issue counts, and descriptions.
+
+## `.github/workflows/notion-runs-board-sync.yml`
+
+Maintains the automation runs ledger in Notion so that every CI/CD execution is
+captured for auditability.
+
+- **Triggers:** any completed GitHub Actions workflow run (excluding the runs board
+  workflow itself to avoid recursion).
+- **Target database:** `${{ secrets.NOTION_RUNS_BOARD_ID }}` or
+  `vars.RUNS_DATABASE_ID`.
+- **Behaviour:** Executes `python -m agent_logic.notion_sync.entity_cli runs` with
+  the workflow payload to persist run metadata (workflow name, run number, status,
+  conclusion, and timestamps). This forms the audit trail requested in the task
+  directive.
+
+## Operational Notes
+
+1. Run `verify-env-vars.yml` after provisioning new secrets to ensure they are
+   accessible to Actions runners.
+2. The CLI supports a `--dry-run` flag that can be added in manual dispatches to
+   validate the connection without mutating Notion.
+3. When new properties are added to Notion databases, update the corresponding
+   repository variables (for example `TASK_UNIQUE_PROPERTY`) so the workflows point
+   to the correct property names.
+4. The runs board workflow relies on the standard `GITHUB_EVENT_PATH` file provided
+   during `workflow_run` executions. No additional configuration is required beyond
+   the Notion credentials.
+
+Keeping the documentation in `.github/docs/` ensures that future contributors can
+quickly audit automation coverage without searching through individual YAML files.

--- a/.github/workflows/notion-issue-sync.yml
+++ b/.github/workflows/notion-issue-sync.yml
@@ -1,0 +1,59 @@
+name: Notion Issue Sync
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sync:
+    name: Sync issues database
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise issues with Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_ACTIONS != '' && secrets.AGENT_ACTIONS || secrets.GITHUB_TOKEN }}
+          ISSUE_DATABASE_ID: ${{ secrets.NOTION_ISSUES_DB_ID != '' && secrets.NOTION_ISSUES_DB_ID || vars.ISSUE_DATABASE_ID }}
+          ISSUE_UNIQUE_PROPERTY: ${{ vars.ISSUE_UNIQUE_PROPERTY || 'GitHub ID' }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "::error::NOTION_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$ISSUE_DATABASE_ID" ]; then
+            echo "::error::Issue database identifier is not configured."
+            exit 1
+          fi
+          python -m agent_logic.notion_sync.entity_cli issues \
+            --database-id "$ISSUE_DATABASE_ID" \
+            --unique-property "$ISSUE_UNIQUE_PROPERTY"

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -1,0 +1,55 @@
+name: Notion Pull Request Sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sync:
+    name: Sync pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise pull requests with Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_ACTIONS != '' && secrets.AGENT_ACTIONS || secrets.GITHUB_TOKEN }}
+          PR_DATABASE_ID: ${{ secrets.NOTION_PR_DB_ID != '' && secrets.NOTION_PR_DB_ID || vars.PR_DATABASE_ID }}
+          PR_UNIQUE_PROPERTY: ${{ vars.PR_UNIQUE_PROPERTY || 'GitHub ID' }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "::error::NOTION_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$PR_DATABASE_ID" ]; then
+            echo "::error::Pull request database identifier is not configured."
+            exit 1
+          fi
+          python -m agent_logic.notion_sync.entity_cli pull-requests \
+            --database-id "$PR_DATABASE_ID" \
+            --unique-property "$PR_UNIQUE_PROPERTY"

--- a/.github/workflows/notion-project-sync.yml
+++ b/.github/workflows/notion-project-sync.yml
@@ -1,0 +1,51 @@
+name: Notion Project Sync
+
+on:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync project milestones
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise project milestones with Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_ACTIONS != '' && secrets.AGENT_ACTIONS || secrets.GITHUB_TOKEN }}
+          PROJECT_DATABASE_ID: ${{ secrets.NOTION_PROJECTS_DB_ID != '' && secrets.NOTION_PROJECTS_DB_ID || vars.PROJECT_DATABASE_ID }}
+          PROJECT_UNIQUE_PROPERTY: ${{ vars.PROJECT_UNIQUE_PROPERTY || 'GitHub ID' }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "::error::NOTION_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$PROJECT_DATABASE_ID" ]; then
+            echo "::error::Project database identifier is not configured."
+            exit 1
+          fi
+          python -m agent_logic.notion_sync.entity_cli projects \
+            --database-id "$PROJECT_DATABASE_ID" \
+            --unique-property "$PROJECT_UNIQUE_PROPERTY"

--- a/.github/workflows/notion-runs-board-sync.yml
+++ b/.github/workflows/notion-runs-board-sync.yml
@@ -1,0 +1,52 @@
+name: Notion Runs Board Sync
+
+on:
+  workflow_run:
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: github.event.workflow_run.name != 'Notion Runs Board Sync'
+    name: Record workflow execution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Update runs board in Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_ACTIONS != '' && secrets.AGENT_ACTIONS || secrets.GITHUB_TOKEN }}
+          RUNS_DATABASE_ID: ${{ secrets.NOTION_RUNS_BOARD_ID != '' && secrets.NOTION_RUNS_BOARD_ID || vars.RUNS_DATABASE_ID }}
+          RUNS_UNIQUE_PROPERTY: ${{ vars.RUNS_UNIQUE_PROPERTY || 'GitHub ID' }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "::error::NOTION_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$RUNS_DATABASE_ID" ]; then
+            echo "::error::Runs board database identifier is not configured."
+            exit 1
+          fi
+          python -m agent_logic.notion_sync.entity_cli runs \
+            --database-id "$RUNS_DATABASE_ID" \
+            --unique-property "$RUNS_UNIQUE_PROPERTY" \
+            --event-path "$GITHUB_EVENT_PATH"

--- a/.github/workflows/notion-task-sync.yml
+++ b/.github/workflows/notion-task-sync.yml
@@ -1,0 +1,64 @@
+name: Notion Task Sync
+
+on:
+  push:
+    branches:
+      - "**"
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sync:
+    name: Sync task database
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Synchronise task items with Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_ACTIONS != '' && secrets.AGENT_ACTIONS || secrets.GITHUB_TOKEN }}
+          TASK_DATABASE_ID: ${{ secrets.NOTION_TASK_DB_ID != '' && secrets.NOTION_TASK_DB_ID || vars.TASK_DATABASE_ID }}
+          TASK_LABEL: ${{ vars.TASK_LABEL || 'task' }}
+          TASK_UNIQUE_PROPERTY: ${{ vars.TASK_UNIQUE_PROPERTY || 'GitHub ID' }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "::error::NOTION_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN secret is not configured."
+            exit 1
+          fi
+          if [ -z "$TASK_DATABASE_ID" ]; then
+            echo "::error::Task database identifier is not configured."
+            exit 1
+          fi
+          python -m agent_logic.notion_sync.entity_cli tasks \
+            --database-id "$TASK_DATABASE_ID" \
+            --task-label "$TASK_LABEL" \
+            --unique-property "$TASK_UNIQUE_PROPERTY"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.31.0
 
 # Test dependencies
 pytest>=7.4.0
+responses>=0.25.0

--- a/src/agent_logic/notion_sync/entity_cli.py
+++ b/src/agent_logic/notion_sync/entity_cli.py
@@ -1,0 +1,146 @@
+"""Command line interface for GitHub ⇆ Notion synchronisation."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Iterable, List, Mapping
+
+from .client import GitHubApiError, GitHubClient, NotionApi, NotionApiError
+from .entity_sync import (
+    EntitySyncSummary,
+    NotionDatabaseSyncer,
+    build_issue_content,
+    build_milestone_content,
+    build_pull_request_content,
+    build_run_content,
+    build_task_content,
+    fetch_milestones,
+    fetch_pull_requests,
+    fetch_repository_issues,
+    fetch_task_issues,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synchronise GitHub artefacts with Notion databases")
+    parser.add_argument("command", choices=["tasks", "pull-requests", "issues", "projects", "runs"], help="Entity to sync")
+    parser.add_argument("--database-id", required=True, help="Target Notion database identifier")
+    parser.add_argument("--unique-property", default="GitHub ID", help="Notion property used as the unique key")
+    parser.add_argument("--repository", help="GitHub repository in owner/name format")
+    parser.add_argument("--task-label", default="task", help="Label used to identify GitHub task issues")
+    parser.add_argument("--dry-run", action="store_true", help="Run without writing to Notion")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (default: INFO)")
+    parser.add_argument(
+        "--event-path",
+        help="Path to the GitHub Actions event payload (for workflow run sync)",
+    )
+    return parser
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name!r} must be configured")
+    return value
+
+
+def _build_clients() -> tuple[NotionApi, GitHubClient]:
+    notion_token = _require_env("NOTION_TOKEN")
+    github_token = _require_env("GITHUB_TOKEN")
+    return NotionApi(notion_token), GitHubClient(github_token)
+
+
+def _resolve_repository(args: argparse.Namespace) -> str:
+    repository = args.repository or os.environ.get("GITHUB_REPOSITORY")
+    if not repository:
+        raise RuntimeError("GitHub repository must be provided via --repository or GITHUB_REPOSITORY")
+    return repository
+
+
+def _sync_with_summary(
+    syncer: NotionDatabaseSyncer,
+    contents: Iterable[Mapping[str, object]],
+    builder,
+    *,
+    dry_run: bool,
+) -> EntitySyncSummary:
+    pages = [builder(item) for item in contents]
+    return syncer.sync(pages, dry_run=dry_run)
+
+
+def _load_workflow_run(event_path: str) -> Mapping[str, object]:
+    with open(event_path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if "workflow_run" not in payload:
+        raise RuntimeError("Event payload does not contain workflow_run data")
+    run = payload["workflow_run"]
+    if "workflow" in payload and isinstance(payload["workflow"], Mapping):
+        run.setdefault("workflow_name", payload["workflow"].get("name"))
+    return run
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    logger = logging.getLogger("notion-entity-sync")
+
+    try:
+        notion_api, github_client = _build_clients()
+    except RuntimeError as exc:
+        logger.error(str(exc))
+        return 1
+
+    syncer = NotionDatabaseSyncer(
+        notion_api,
+        database_id=args.database_id,
+        unique_property=args.unique_property,
+        logger=logger,
+    )
+
+    try:
+        if args.command == "tasks":
+            repository = _resolve_repository(args)
+            issues = fetch_task_issues(github_client, repository, label=args.task_label)
+            summary = _sync_with_summary(syncer, issues, build_task_content, dry_run=args.dry_run)
+        elif args.command == "issues":
+            repository = _resolve_repository(args)
+            issues = fetch_repository_issues(github_client, repository)
+            summary = _sync_with_summary(syncer, issues, build_issue_content, dry_run=args.dry_run)
+        elif args.command == "pull-requests":
+            repository = _resolve_repository(args)
+            pull_requests = fetch_pull_requests(github_client, repository)
+            summary = _sync_with_summary(syncer, pull_requests, build_pull_request_content, dry_run=args.dry_run)
+        elif args.command == "projects":
+            repository = _resolve_repository(args)
+            milestones = fetch_milestones(github_client, repository)
+            summary = _sync_with_summary(syncer, milestones, build_milestone_content, dry_run=args.dry_run)
+        elif args.command == "runs":
+            event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+            if not event_path:
+                raise RuntimeError("workflow_run payload path must be provided via --event-path or GITHUB_EVENT_PATH")
+            run = _load_workflow_run(event_path)
+            summary = syncer.sync([build_run_content(run)], dry_run=args.dry_run)
+        else:  # pragma: no cover - defensive
+            parser.error(f"Unknown command: {args.command}")
+            return 2
+    except (RuntimeError, GitHubApiError, NotionApiError) as exc:
+        logger.error("Failed to complete synchronisation: %s", exc)
+        return 1
+
+    logger.info(
+        "Processed %s records (%s created, %s updated, %s skipped)",
+        summary.processed,
+        summary.created,
+        summary.updated,
+        summary.skipped,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/agent_logic/notion_sync/entity_sync.py
+++ b/src/agent_logic/notion_sync/entity_sync.py
@@ -1,0 +1,345 @@
+"""Helpers for synchronising GitHub entities with Notion databases."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from .client import GitHubClient, NotionApi
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PageContent:
+    """Represents the Notion properties required to sync a single entity."""
+
+    key: str
+    properties: Dict[str, object]
+
+
+@dataclass
+class EntitySyncSummary:
+    """Summarises the outcome of a synchronisation run."""
+
+    processed: int = 0
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    dry_run: bool = False
+
+    def record_created(self) -> None:
+        self.processed += 1
+        self.created += 1
+
+    def record_updated(self) -> None:
+        self.processed += 1
+        self.updated += 1
+
+    def record_skipped(self) -> None:
+        self.processed += 1
+        self.skipped += 1
+
+
+class NotionDatabaseSyncer:
+    """Synchronises a collection of :class:`PageContent` entries to Notion."""
+
+    def __init__(
+        self,
+        notion_api: NotionApi,
+        *,
+        database_id: str,
+        unique_property: str = "GitHub ID",
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._notion = notion_api
+        self._database_id = database_id
+        self._unique_property = unique_property
+        self._logger = logger or LOGGER
+
+    # ------------------------------------------------------------------
+    def sync(self, contents: Iterable[PageContent], *, dry_run: bool = False) -> EntitySyncSummary:
+        summary = EntitySyncSummary(dry_run=dry_run)
+        page_map = self._build_page_index()
+
+        for content in contents:
+            page_id = page_map.get(content.key)
+            if dry_run:
+                self._logger.info("Dry-run mode active; skipping sync for %s", content.key)
+                summary.record_skipped()
+                continue
+
+            if page_id:
+                self._notion.update_page(page_id, content.properties)
+                self._logger.debug("Updated Notion page %s", page_id)
+                summary.record_updated()
+            else:
+                payload = {
+                    "parent": {"database_id": self._database_id},
+                    "properties": content.properties,
+                }
+                self._notion.create_page(payload)
+                self._logger.debug("Created Notion page for %s", content.key)
+                summary.record_created()
+
+        return summary
+
+    # ------------------------------------------------------------------
+    def _build_page_index(self) -> MutableMapping[str, str]:
+        index: MutableMapping[str, str] = {}
+        for page in self._notion.list_database_pages(self._database_id):
+            key = self._extract_property_value(page.get("properties", {}))
+            if key:
+                index[key] = page.get("id", "")
+        return index
+
+    def _extract_property_value(self, properties: Mapping[str, object]) -> Optional[str]:
+        property_value = properties.get(self._unique_property)
+        if not isinstance(property_value, Mapping):
+            return None
+
+        prop_type = property_value.get("type")
+        if prop_type == "rich_text":
+            return _collect_plain_text(property_value.get("rich_text", [])) or None
+        if prop_type == "title":
+            return _collect_plain_text(property_value.get("title", [])) or None
+        if prop_type == "number":
+            number = property_value.get("number")
+            return str(int(number)) if isinstance(number, (int, float)) else None
+        if prop_type in {"status", "select"}:
+            option = property_value.get(prop_type) or {}
+            name = option.get("name")
+            return name if name else None
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Property helpers
+
+
+def _collect_plain_text(blocks: Sequence[Mapping[str, object]]) -> str:
+    text = []
+    for block in blocks:
+        if isinstance(block, Mapping):
+            text.append(str(block.get("plain_text") or block.get("text", {}).get("content", "")))
+    return "".join(text).strip()
+
+
+def _title(text: str) -> Dict[str, object]:
+    return {
+        "title": [
+            {
+                "text": {
+                    "content": text[:2000],
+                }
+            }
+        ]
+    }
+
+
+def _rich_text(content: str) -> Dict[str, object]:
+    return {
+        "rich_text": [
+            {
+                "text": {
+                    "content": content[:2000],
+                }
+            }
+        ]
+    }
+
+
+def _multi_select(values: Iterable[str]) -> Dict[str, object]:
+    options = [{"name": value[:100]} for value in values if value]
+    return {"multi_select": options}
+
+
+def _status(name: Optional[str]) -> Dict[str, object]:
+    if not name:
+        return {"status": None}
+    return {"status": {"name": name[:100]}}
+
+
+def _select(name: Optional[str]) -> Dict[str, object]:
+    if not name:
+        return {"select": None}
+    return {"select": {"name": name[:100]}}
+
+
+def _date(value: Optional[str]) -> Dict[str, object]:
+    if not value:
+        return {"date": None}
+    return {"date": {"start": value}}
+
+
+def _number(value: Optional[int]) -> Dict[str, object]:
+    if value is None:
+        return {"number": None}
+    return {"number": value}
+
+
+def _normalise_state(state: Optional[str]) -> str:
+    if not state:
+        return "Unknown"
+    return state.replace("_", " ").strip().title()
+
+
+def _to_iso8601(value: Optional[object]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Builders for individual GitHub entities
+
+
+def build_task_content(issue: Mapping[str, object]) -> PageContent:
+    key = str(issue.get("node_id") or issue.get("id") or issue.get("number"))
+    title = str(issue.get("title") or f"Task {issue.get('number')}")
+    url = issue.get("html_url")
+    state = _normalise_state("closed" if issue.get("closed_at") else issue.get("state"))
+    labels = [label.get("name") for label in issue.get("labels", []) if isinstance(label, Mapping)]
+    assignees = [user.get("login") for user in issue.get("assignees", []) if isinstance(user, Mapping)]
+    closed_at = _to_iso8601(issue.get("closed_at"))
+
+    properties: Dict[str, object] = {
+        "Name": _title(title),
+        "GitHub ID": _rich_text(key),
+        "GitHub URL": {"url": url},
+        "Status": _status("Closed" if closed_at else "Open"),
+        "Labels": _multi_select(labels),
+        "Assignees": _multi_select(assignees),
+        "GitHub Number": _number(issue.get("number") if isinstance(issue.get("number"), int) else None),
+        "Completed At": _date(closed_at),
+        "Updated At": _date(_to_iso8601(issue.get("updated_at"))),
+    }
+
+    return PageContent(key=key, properties=properties)
+
+
+def build_issue_content(issue: Mapping[str, object]) -> PageContent:
+    key = str(issue.get("node_id") or issue.get("id") or issue.get("number"))
+    title = str(issue.get("title") or f"Issue {issue.get('number')}")
+    url = issue.get("html_url")
+    state = _normalise_state(issue.get("state"))
+    labels = [label.get("name") for label in issue.get("labels", []) if isinstance(label, Mapping)]
+    assignees = [user.get("login") for user in issue.get("assignees", []) if isinstance(user, Mapping)]
+
+    properties: Dict[str, object] = {
+        "Name": _title(title),
+        "GitHub ID": _rich_text(key),
+        "GitHub URL": {"url": url},
+        "Status": _status(state),
+        "Labels": _multi_select(labels),
+        "Assignees": _multi_select(assignees),
+        "GitHub Number": _number(issue.get("number") if isinstance(issue.get("number"), int) else None),
+        "Updated At": _date(_to_iso8601(issue.get("updated_at"))),
+        "Closed At": _date(_to_iso8601(issue.get("closed_at"))),
+    }
+
+    return PageContent(key=key, properties=properties)
+
+
+def build_pull_request_content(pr: Mapping[str, object]) -> PageContent:
+    key = str(pr.get("node_id") or pr.get("id") or pr.get("number"))
+    title = str(pr.get("title") or f"PR {pr.get('number')}")
+    url = pr.get("html_url")
+    state = "Merged" if pr.get("merged_at") else _normalise_state(pr.get("state"))
+    labels = [label.get("name") for label in pr.get("labels", []) if isinstance(label, Mapping)]
+    assignees = [user.get("login") for user in pr.get("assignees", []) if isinstance(user, Mapping)]
+    author = pr.get("user") or {}
+
+    properties: Dict[str, object] = {
+        "Name": _title(title),
+        "GitHub ID": _rich_text(key),
+        "GitHub URL": {"url": url},
+        "Status": _status(state),
+        "Labels": _multi_select(labels),
+        "Assignees": _multi_select(assignees),
+        "Author": _multi_select([author.get("login")] if isinstance(author, Mapping) else []),
+        "GitHub Number": _number(pr.get("number") if isinstance(pr.get("number"), int) else None),
+        "Merged At": _date(_to_iso8601(pr.get("merged_at"))),
+        "Updated At": _date(_to_iso8601(pr.get("updated_at"))),
+    }
+
+    return PageContent(key=key, properties=properties)
+
+
+def build_milestone_content(milestone: Mapping[str, object]) -> PageContent:
+    key = str(milestone.get("node_id") or milestone.get("id") or milestone.get("number"))
+    title = str(milestone.get("title") or f"Milestone {milestone.get('number')}")
+    url = milestone.get("html_url")
+    state = _normalise_state(milestone.get("state"))
+
+    properties: Dict[str, object] = {
+        "Name": _title(title),
+        "GitHub ID": _rich_text(key),
+        "GitHub URL": {"url": url},
+        "Status": _status(state),
+        "GitHub Number": _number(milestone.get("number") if isinstance(milestone.get("number"), int) else None),
+        "Due Date": _date(_to_iso8601(milestone.get("due_on"))),
+        "Open Issues": _number(milestone.get("open_issues") if isinstance(milestone.get("open_issues"), int) else None),
+        "Closed Issues": _number(milestone.get("closed_issues") if isinstance(milestone.get("closed_issues"), int) else None),
+    }
+
+    description = milestone.get("description")
+    if description:
+        properties["Description"] = _rich_text(str(description))
+
+    return PageContent(key=key, properties=properties)
+
+
+def build_run_content(run: Mapping[str, object]) -> PageContent:
+    key = str(run.get("id") or run.get("run_id") or run.get("run_number"))
+    workflow_name = str(run.get("name") or run.get("workflow_name") or "Workflow")
+    url = run.get("html_url")
+    status = _normalise_state(run.get("status"))
+    conclusion = run.get("conclusion")
+
+    properties: Dict[str, object] = {
+        "Name": _title(f"{workflow_name} #{run.get('run_number')}") if run.get("run_number") else _title(workflow_name),
+        "GitHub ID": _rich_text(key),
+        "GitHub URL": {"url": url},
+        "Status": _status(status),
+        "Result": _select(_normalise_state(conclusion) if conclusion else None),
+        "Run Number": _number(run.get("run_number") if isinstance(run.get("run_number"), int) else None),
+        "Workflow": _rich_text(workflow_name),
+        "Started At": _date(_to_iso8601(run.get("run_started_at"))),
+        "Completed At": _date(_to_iso8601(run.get("updated_at"))),
+    }
+
+    return PageContent(key=key, properties=properties)
+
+
+def filter_github_issues(issues: Iterable[Mapping[str, object]]) -> List[Mapping[str, object]]:
+    """Return issues that are not pull requests."""
+
+    return [issue for issue in issues if "pull_request" not in issue]
+
+
+def fetch_task_issues(client: GitHubClient, repository: str, *, label: Optional[str]) -> List[Mapping[str, object]]:
+    issues = list(client.list_repository_issues(repository, state="all", labels=label)) if label else list(
+        client.list_repository_issues(repository, state="all")
+    )
+    return filter_github_issues(issues)
+
+
+def fetch_repository_issues(client: GitHubClient, repository: str) -> List[Mapping[str, object]]:
+    return filter_github_issues(client.list_repository_issues(repository, state="all"))
+
+
+def fetch_pull_requests(client: GitHubClient, repository: str) -> List[Mapping[str, object]]:
+    return list(client.list_pull_requests(repository, state="all"))
+
+
+def fetch_milestones(client: GitHubClient, repository: str) -> List[Mapping[str, object]]:
+    return list(client.list_milestones(repository, state="all"))

--- a/tests/notion_sync/test_entity_sync.py
+++ b/tests/notion_sync/test_entity_sync.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import responses
+
+from agent_logic.notion_sync.entity_sync import (
+    NotionDatabaseSyncer,
+    PageContent,
+    build_pull_request_content,
+    build_run_content,
+    build_task_content,
+)
+from agent_logic.notion_sync.client import NotionApi
+
+
+@pytest.fixture()
+def notion_api() -> NotionApi:
+    return NotionApi("token")
+
+
+@responses.activate
+def test_sync_creates_new_pages(notion_api: NotionApi) -> None:
+    responses.add(
+        responses.POST,
+        "https://api.notion.com/v1/databases/tasks/query",
+        json={"results": [], "has_more": False},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.notion.com/v1/pages",
+        json={"id": "new-page"},
+        status=200,
+    )
+
+    syncer = NotionDatabaseSyncer(notion_api, database_id="tasks")
+    content = PageContent(key="123", properties={"Name": {"title": [{"text": {"content": "Example"}}]}})
+
+    summary = syncer.sync([content])
+
+    assert summary.created == 1
+    assert summary.updated == 0
+
+    assert len(responses.calls) == 2
+    payload = json.loads(responses.calls[1].request.body)
+    assert payload["parent"]["database_id"] == "tasks"
+    assert payload["properties"]["Name"]["title"][0]["text"]["content"] == "Example"
+
+
+@responses.activate
+def test_sync_updates_existing_page(notion_api: NotionApi) -> None:
+    responses.add(
+        responses.POST,
+        "https://api.notion.com/v1/databases/tasks/query",
+        json={
+            "results": [
+                {
+                    "id": "page-1",
+                    "properties": {
+                        "GitHub ID": {
+                            "type": "rich_text",
+                            "rich_text": [
+                                {
+                                    "plain_text": "123",
+                                }
+                            ],
+                        }
+                    },
+                }
+            ],
+            "has_more": False,
+        },
+        status=200,
+    )
+    responses.add(
+        responses.PATCH,
+        "https://api.notion.com/v1/pages/page-1",
+        json={"id": "page-1"},
+        status=200,
+    )
+
+    syncer = NotionDatabaseSyncer(notion_api, database_id="tasks")
+    content = PageContent(key="123", properties={"Name": {"title": [{"text": {"content": "Updated"}}]}})
+
+    summary = syncer.sync([content])
+
+    assert summary.updated == 1
+    assert summary.created == 0
+
+    assert len(responses.calls) == 2
+    payload = json.loads(responses.calls[1].request.body)
+    assert payload["properties"]["Name"]["title"][0]["text"]["content"] == "Updated"
+
+
+@responses.activate
+def test_sync_dry_run_skips_writes(notion_api: NotionApi) -> None:
+    responses.add(
+        responses.POST,
+        "https://api.notion.com/v1/databases/tasks/query",
+        json={"results": [], "has_more": False},
+        status=200,
+    )
+
+    syncer = NotionDatabaseSyncer(notion_api, database_id="tasks")
+    content = PageContent(key="123", properties={"Name": {"title": [{"text": {"content": "Example"}}]}})
+
+    summary = syncer.sync([content], dry_run=True)
+
+    assert summary.skipped == 1
+    assert summary.created == 0
+    assert summary.updated == 0
+    assert len(responses.calls) == 1
+
+
+def test_build_task_content_contains_expected_fields() -> None:
+    issue = {
+        "id": 42,
+        "number": 7,
+        "title": "Implement feature",
+        "html_url": "https://github.com/org/repo/issues/7",
+        "labels": [
+            {"name": "task"},
+            {"name": "backend"},
+        ],
+        "assignees": [
+            {"login": "octocat"},
+        ],
+        "updated_at": "2024-01-01T12:00:00Z",
+        "closed_at": None,
+    }
+
+    content = build_task_content(issue)
+    assert content.key == "42"
+    assert content.properties["GitHub Number"]["number"] == 7
+    assert content.properties["Status"]["status"]["name"] == "Open"
+    labels = {item["name"] for item in content.properties["Labels"]["multi_select"]}
+    assert labels == {"task", "backend"}
+
+
+def test_build_pull_request_content_marks_merged() -> None:
+    pull_request = {
+        "id": 99,
+        "number": 10,
+        "title": "Add sync workflow",
+        "html_url": "https://github.com/org/repo/pull/10",
+        "state": "closed",
+        "merged_at": "2024-02-02T10:00:00Z",
+        "labels": [],
+        "assignees": [],
+        "user": {"login": "octocat"},
+    }
+
+    content = build_pull_request_content(pull_request)
+    assert content.properties["Status"]["status"]["name"] == "Merged"
+    author = content.properties["Author"]["multi_select"][0]["name"]
+    assert author == "octocat"
+
+
+def test_build_run_content_uses_run_number() -> None:
+    run = {
+        "id": 1234,
+        "name": "CI",
+        "run_number": 56,
+        "status": "completed",
+        "conclusion": "success",
+        "html_url": "https://github.com/org/repo/actions/runs/1234",
+        "updated_at": "2024-03-03T12:00:00Z",
+    }
+
+    content = build_run_content(run)
+    assert "CI #56" in content.properties["Name"]["title"][0]["text"]["content"]
+    assert content.properties["Result"]["select"]["name"] == "Success"


### PR DESCRIPTION
## Summary
- add Python utilities for syncing GitHub issues, pull requests, milestones, and workflow runs into Notion databases
- extend the Notion/GitHub clients and document the new automation workflows that connect to the Codex Notion workspace
- create GitHub Actions workflows that invoke the sync utilities for tasks, pull requests, issues, projects, and workflow run audit logging

## Testing
- `pytest tests/notion_sync -q`


------
https://chatgpt.com/codex/tasks/task_e_68fe99c3776c8323ae9eb17f4e14fae1